### PR TITLE
Remove USE_COCOA flag and manually move the binary when building on OS X

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -68,10 +68,12 @@ util.build = function (url, dest, cb) {
 	var self = this;
 	var file = path.join(tmpdir, path.basename(url));
 	var tmp = path.join(tmpdir, path.basename(file, '.tar.gz'));
-	var buildScript = 'make install BINPREFIX='+ dest;
+  /* FIXME was 'make install BINPREFIX='+ dest but the make install of pngquant
+     is broken in OS X. When it will be fixed, restore the old behaviour */
+	var buildScript = 'make';
 
 	if (process.platform === 'darwin') {
-		buildScript += ' USE_COCOA=1 CFLAGSADD="-mmacosx-version-min=10.7"';
+		buildScript += ' CFLAGSADD="-mmacosx-version-min=10.7"';
 	}
 
 	try {
@@ -90,12 +92,21 @@ util.build = function (url, dest, cb) {
 				return cb(new Error(err.message));
 			}
 
+
 			exec(buildScript, { cwd: tmp }, function (err) {
 				if (err) {
 					return cb(new Error(err.message));
 				}
 
-				cb();
+				// FIXME when the 'make install' of pngquant works again,
+				// remove this and just call cb()
+				fs.rename(tmp+'/pngquant', dest+'/pngquant', function(err){
+					if (err) {
+						return cb(new Error(err.message));
+					}
+
+					cb();
+				});
 			});
 		});
 	});


### PR DESCRIPTION
Now it is able to compile on OS X  and passes all the tests. I found another issue that is related with the command `make install DESTINATION_PATH`, internally it uses `install` with a parameter -D, this is only present in the GNU versions so it fails on OS X. As a workaround it manually moves the binary to the correct location.
