### PR TITLE
Warn about OS X missing essential libraries

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,12 @@
 
 ## Install
 
+On OS X 10.9+ you need to install libpng first:
+
+```bash
+$ brew install libpng
+```
+
 ```bash
 $ npm install --save pngquant-bin
 ```


### PR DESCRIPTION
Sadly Apple stopped shipping libpng with Mac OS X, so now it's necessary to install libpng manually.
