### PR TITLE
Add npm lock file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6659 @@
+{
+	"name": "pngquant-bin",
+	"version": "3.1.1",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"@ava/babel-plugin-throws-helper": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@ava/babel-plugin-throws-helper/-/babel-plugin-throws-helper-2.0.0.tgz",
+			"integrity": "sha1-L8H+PCEacQcaTsp7j3r1hCzRrnw=",
+			"dev": true
+		},
+		"@ava/babel-preset-stage-4": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@ava/babel-preset-stage-4/-/babel-preset-stage-4-1.1.0.tgz",
+			"integrity": "sha512-oWqTnIGXW3k72UFidXzW0ONlO7hnO9x02S/QReJ7NBGeiBH9cUHY9+EfV6C8PXC6YJH++WrliEq03wMSJGNZFg==",
+			"dev": true,
+			"requires": {
+				"babel-plugin-check-es2015-constants": "6.22.0",
+				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
+				"babel-plugin-transform-async-to-generator": "6.24.1",
+				"babel-plugin-transform-es2015-destructuring": "6.23.0",
+				"babel-plugin-transform-es2015-function-name": "6.24.1",
+				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+				"babel-plugin-transform-es2015-parameters": "6.24.1",
+				"babel-plugin-transform-es2015-spread": "6.22.0",
+				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+				"babel-plugin-transform-exponentiation-operator": "6.24.1",
+				"package-hash": "1.2.0"
+			},
+			"dependencies": {
+				"md5-hex": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
+					"integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+					"dev": true,
+					"requires": {
+						"md5-o-matic": "0.1.1"
+					}
+				},
+				"package-hash": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-1.2.0.tgz",
+					"integrity": "sha1-AD5WzVe3NqbtYRTMK4FUJnJ3DkQ=",
+					"dev": true,
+					"requires": {
+						"md5-hex": "1.3.0"
+					}
+				}
+			}
+		},
+		"@ava/babel-preset-transform-test-files": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@ava/babel-preset-transform-test-files/-/babel-preset-transform-test-files-3.0.0.tgz",
+			"integrity": "sha1-ze0RlqjY2TgaUJJAq5LpGl7Aafc=",
+			"dev": true,
+			"requires": {
+				"@ava/babel-plugin-throws-helper": "2.0.0",
+				"babel-plugin-espower": "2.3.2"
+			}
+		},
+		"@ava/write-file-atomic": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@ava/write-file-atomic/-/write-file-atomic-2.2.0.tgz",
+			"integrity": "sha512-BTNB3nGbEfJT+69wuqXFr/bQH7Vr7ihx2xGOMNqPgDGhwspoZhiWumDDZNjBy7AScmqS5CELIOGtPVXESyrnDA==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"imurmurhash": "0.1.4",
+				"slide": "1.1.6"
+			}
+		},
+		"@concordance/react": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@concordance/react/-/react-1.0.0.tgz",
+			"integrity": "sha512-htrsRaQX8Iixlsek8zQU7tE8wcsTQJ5UhZkSPEA8slCDAisKpC/2VgU/ucPn32M5/LjGGXRaUEKvEw1Wiuu4zQ==",
+			"dev": true,
+			"requires": {
+				"arrify": "1.0.1"
+			}
+		},
+		"acorn": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+			"integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+			"dev": true
+		},
+		"acorn-jsx": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+			"dev": true,
+			"requires": {
+				"acorn": "3.3.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+					"integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+					"dev": true
+				}
+			}
+		},
+		"ajv": {
+			"version": "4.11.8",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+			"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+			"dev": true,
+			"requires": {
+				"co": "4.6.0",
+				"json-stable-stringify": "1.0.1"
+			},
+			"dependencies": {
+				"co": {
+					"version": "4.6.0",
+					"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+					"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+					"dev": true
+				}
+			}
+		},
+		"ajv-keywords": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+			"integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+			"dev": true
+		},
+		"ansi-align": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+			"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+			"dev": true,
+			"requires": {
+				"string-width": "2.1.1"
+			}
+		},
+		"ansi-escapes": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+			"integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+			"dev": true
+		},
+		"ansi-regex": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+		},
+		"ansi-styles": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+		},
+		"anymatch": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+			"dev": true,
+			"requires": {
+				"micromatch": "2.3.11",
+				"normalize-path": "2.1.1"
+			}
+		},
+		"archive-type": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/archive-type/-/archive-type-3.2.0.tgz",
+			"integrity": "sha1-nNnABpV+vpX62tW9YJiUKoE3N/Y=",
+			"requires": {
+				"file-type": "3.9.0"
+			},
+			"dependencies": {
+				"file-type": {
+					"version": "3.9.0",
+					"resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+					"integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
+				}
+			}
+		},
+		"argparse": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+			"dev": true,
+			"requires": {
+				"sprintf-js": "1.0.3"
+			}
+		},
+		"arr-diff": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+			"requires": {
+				"arr-flatten": "1.1.0"
+			}
+		},
+		"arr-exclude": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/arr-exclude/-/arr-exclude-1.0.0.tgz",
+			"integrity": "sha1-38fC5VKicHI8zaBM8xKMjL/lxjE=",
+			"dev": true
+		},
+		"arr-flatten": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+		},
+		"array-differ": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
+		},
+		"array-find-index": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+		},
+		"array-union": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+			"dev": true,
+			"requires": {
+				"array-uniq": "1.0.3"
+			}
+		},
+		"array-uniq": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+		},
+		"array-unique": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+		},
+		"arrify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
+		},
+		"async-each": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+			"dev": true
+		},
+		"auto-bind": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-1.1.0.tgz",
+			"integrity": "sha1-k7hk3H7gGjJigXddXHXKCnUeWWE=",
+			"dev": true
+		},
+		"ava": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/ava/-/ava-0.24.0.tgz",
+			"integrity": "sha512-o/ykNzsWB5qgh1cR9jzVw0E1y4E219aXl9njNFGSamSCsD7VhPd3aoZabNZuG1PSVMZmQ8RuwKnTuz/loNhKnw==",
+			"dev": true,
+			"requires": {
+				"@ava/babel-preset-stage-4": "1.1.0",
+				"@ava/babel-preset-transform-test-files": "3.0.0",
+				"@ava/write-file-atomic": "2.2.0",
+				"@concordance/react": "1.0.0",
+				"ansi-escapes": "3.0.0",
+				"ansi-styles": "3.2.0",
+				"arr-flatten": "1.1.0",
+				"array-union": "1.0.2",
+				"array-uniq": "1.0.3",
+				"arrify": "1.0.1",
+				"auto-bind": "1.1.0",
+				"ava-init": "0.2.1",
+				"babel-core": "6.26.0",
+				"babel-generator": "6.26.0",
+				"babel-plugin-syntax-object-rest-spread": "6.13.0",
+				"bluebird": "3.5.1",
+				"caching-transform": "1.0.1",
+				"chalk": "2.3.0",
+				"chokidar": "1.7.0",
+				"clean-stack": "1.3.0",
+				"clean-yaml-object": "0.1.0",
+				"cli-cursor": "2.1.0",
+				"cli-spinners": "1.1.0",
+				"cli-truncate": "1.1.0",
+				"co-with-promise": "4.6.0",
+				"code-excerpt": "2.1.0",
+				"common-path-prefix": "1.0.0",
+				"concordance": "3.0.0",
+				"convert-source-map": "1.5.1",
+				"core-assert": "0.2.1",
+				"currently-unhandled": "0.4.1",
+				"debug": "3.1.0",
+				"dot-prop": "4.2.0",
+				"empower-core": "0.6.2",
+				"equal-length": "1.0.1",
+				"figures": "2.0.0",
+				"find-cache-dir": "1.0.0",
+				"fn-name": "2.0.1",
+				"get-port": "3.2.0",
+				"globby": "6.1.0",
+				"has-flag": "2.0.0",
+				"hullabaloo-config-manager": "1.1.1",
+				"ignore-by-default": "1.0.1",
+				"import-local": "0.1.1",
+				"indent-string": "3.2.0",
+				"is-ci": "1.0.10",
+				"is-generator-fn": "1.0.0",
+				"is-obj": "1.0.1",
+				"is-observable": "1.0.0",
+				"is-promise": "2.1.0",
+				"js-yaml": "3.10.0",
+				"last-line-stream": "1.0.0",
+				"lodash.clonedeepwith": "4.5.0",
+				"lodash.debounce": "4.0.8",
+				"lodash.difference": "4.5.0",
+				"lodash.flatten": "4.4.0",
+				"loud-rejection": "1.6.0",
+				"make-dir": "1.1.0",
+				"matcher": "1.0.0",
+				"md5-hex": "2.0.0",
+				"meow": "3.7.0",
+				"ms": "2.1.1",
+				"multimatch": "2.1.0",
+				"observable-to-promise": "0.5.0",
+				"option-chain": "1.0.0",
+				"package-hash": "2.0.0",
+				"pkg-conf": "2.0.0",
+				"plur": "2.1.2",
+				"pretty-ms": "3.1.0",
+				"require-precompiled": "0.1.0",
+				"resolve-cwd": "2.0.0",
+				"safe-buffer": "5.1.1",
+				"semver": "5.4.1",
+				"slash": "1.0.0",
+				"source-map-support": "0.5.0",
+				"stack-utils": "1.0.1",
+				"strip-ansi": "4.0.0",
+				"strip-bom-buf": "1.0.0",
+				"supports-color": "5.0.1",
+				"time-require": "0.1.2",
+				"trim-off-newlines": "1.0.1",
+				"unique-temp-dir": "1.0.0",
+				"update-notifier": "2.3.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "4.5.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "4.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+							"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+							"dev": true,
+							"requires": {
+								"has-flag": "2.0.0"
+							}
+						}
+					}
+				},
+				"figures": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+					"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+					"dev": true,
+					"requires": {
+						"escape-string-regexp": "1.0.5"
+					}
+				},
+				"indent-string": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.0.1.tgz",
+					"integrity": "sha512-7FQGOlSQ+AQxBNXJpVDj8efTA/FtyB5wcNE1omXXJ0cq6jm1jjDwuROlYDbnzHqdNPqliWFhcioCWSyav+xBnA==",
+					"dev": true,
+					"requires": {
+						"has-flag": "2.0.0"
+					}
+				}
+			}
+		},
+		"ava-init": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/ava-init/-/ava-init-0.2.1.tgz",
+			"integrity": "sha512-lXwK5LM+2g1euDRqW1mcSX/tqzY1QU7EjKpqayFPPtNRmbSYZ8RzPO5tqluTToijmtjp2M+pNpVdbcHssC4glg==",
+			"dev": true,
+			"requires": {
+				"arr-exclude": "1.0.0",
+				"execa": "0.7.0",
+				"has-yarn": "1.0.0",
+				"read-pkg-up": "2.0.0",
+				"write-pkg": "3.1.0"
+			},
+			"dependencies": {
+				"execa": {
+					"version": "0.7.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "5.1.0",
+						"get-stream": "3.0.0",
+						"is-stream": "1.1.0",
+						"npm-run-path": "2.0.2",
+						"p-finally": "1.0.0",
+						"signal-exit": "3.0.2",
+						"strip-eof": "1.0.0"
+					}
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
+					"requires": {
+						"locate-path": "2.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+					"dev": true
+				},
+				"load-json-file": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"strip-bom": "3.0.0"
+					}
+				},
+				"path-type": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+					"dev": true,
+					"requires": {
+						"pify": "2.3.0"
+					}
+				},
+				"read-pkg": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "2.0.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "2.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+					"dev": true,
+					"requires": {
+						"find-up": "2.1.0",
+						"read-pkg": "2.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+					"dev": true
+				}
+			}
+		},
+		"babel-code-frame": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
+			}
+		},
+		"babel-core": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
+			"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+			"dev": true,
+			"requires": {
+				"babel-code-frame": "6.26.0",
+				"babel-generator": "6.26.0",
+				"babel-helpers": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-register": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"convert-source-map": "1.5.1",
+				"debug": "2.6.9",
+				"json5": "0.5.1",
+				"lodash": "4.17.4",
+				"minimatch": "3.0.4",
+				"path-is-absolute": "1.0.1",
+				"private": "0.1.8",
+				"slash": "1.0.0",
+				"source-map": "0.5.7"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				}
+			}
+		},
+		"babel-generator": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
+			"integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
+			"dev": true,
+			"requires": {
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"detect-indent": "4.0.0",
+				"jsesc": "1.3.0",
+				"lodash": "4.17.4",
+				"source-map": "0.5.7",
+				"trim-right": "1.0.1"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+					"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+					"dev": true
+				}
+			}
+		},
+		"babel-helper-builder-binary-assignment-operator-visitor": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+			"dev": true,
+			"requires": {
+				"babel-helper-explode-assignable-expression": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-call-delegate": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+			"dev": true,
+			"requires": {
+				"babel-helper-hoist-variables": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-explode-assignable-expression": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-function-name": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+			"dev": true,
+			"requires": {
+				"babel-helper-get-function-arity": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-get-function-arity": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-hoist-variables": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helper-regex": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"lodash": "4.17.4"
+			}
+		},
+		"babel-helper-remap-async-to-generator": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+			"dev": true,
+			"requires": {
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-helpers": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
+			}
+		},
+		"babel-messages": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-check-es2015-constants": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-espower": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-espower/-/babel-plugin-espower-2.3.2.tgz",
+			"integrity": "sha1-VRa4/NsmyfDh2BYHSfbkxl5xJx4=",
+			"dev": true,
+			"requires": {
+				"babel-generator": "6.26.0",
+				"babylon": "6.18.0",
+				"call-matcher": "1.0.1",
+				"core-js": "2.5.1",
+				"espower-location-detector": "1.0.0",
+				"espurify": "1.7.0",
+				"estraverse": "4.2.0"
+			}
+		},
+		"babel-plugin-syntax-async-functions": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+			"dev": true
+		},
+		"babel-plugin-syntax-exponentiation-operator": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+			"dev": true
+		},
+		"babel-plugin-syntax-object-rest-spread": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+			"dev": true
+		},
+		"babel-plugin-syntax-trailing-function-commas": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+			"dev": true
+		},
+		"babel-plugin-transform-async-to-generator": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+			"dev": true,
+			"requires": {
+				"babel-helper-remap-async-to-generator": "6.24.1",
+				"babel-plugin-syntax-async-functions": "6.13.0",
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-destructuring": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-function-name": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+			"dev": true,
+			"requires": {
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-modules-commonjs": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
+			"integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+			"dev": true,
+			"requires": {
+				"babel-plugin-transform-strict-mode": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-parameters": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+			"dev": true,
+			"requires": {
+				"babel-helper-call-delegate": "6.24.1",
+				"babel-helper-get-function-arity": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-spread": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-sticky-regex": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+			"dev": true,
+			"requires": {
+				"babel-helper-regex": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-unicode-regex": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+			"dev": true,
+			"requires": {
+				"babel-helper-regex": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"regexpu-core": "2.0.0"
+			}
+		},
+		"babel-plugin-transform-exponentiation-operator": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+			"dev": true,
+			"requires": {
+				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
+				"babel-runtime": "6.26.0"
+			}
+		},
+		"babel-plugin-transform-strict-mode": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
+			}
+		},
+		"babel-register": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+			"dev": true,
+			"requires": {
+				"babel-core": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"core-js": "2.5.1",
+				"home-or-tmp": "2.0.0",
+				"lodash": "4.17.4",
+				"mkdirp": "0.5.1",
+				"source-map-support": "0.4.18"
+			},
+			"dependencies": {
+				"source-map-support": {
+					"version": "0.4.18",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+					"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+					"dev": true,
+					"requires": {
+						"source-map": "0.5.7"
+					}
+				}
+			}
+		},
+		"babel-runtime": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"dev": true,
+			"requires": {
+				"core-js": "2.5.1",
+				"regenerator-runtime": "0.11.0"
+			}
+		},
+		"babel-template": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"lodash": "4.17.4"
+			}
+		},
+		"babel-traverse": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+			"dev": true,
+			"requires": {
+				"babel-code-frame": "6.26.0",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"debug": "2.6.9",
+				"globals": "9.18.0",
+				"invariant": "2.2.2",
+				"lodash": "4.17.4"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				}
+			}
+		},
+		"babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "6.26.0",
+				"esutils": "2.0.2",
+				"lodash": "4.17.4",
+				"to-fast-properties": "1.0.3"
+			}
+		},
+		"babylon": {
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+			"dev": true
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"base64-js": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+			"integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
+		},
+		"beeper": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+			"integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
+		},
+		"bin-build": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/bin-build/-/bin-build-3.0.0.tgz",
+			"integrity": "sha512-jcUOof71/TNAI2uM5uoUaDq2ePcVBQ3R/qhxAz1rX7UfvduAL/RXD3jXzvn8cVcDJdGVkiR1shal3OH0ImpuhA==",
+			"requires": {
+				"decompress": "4.2.0",
+				"download": "6.2.5",
+				"execa": "0.7.0",
+				"p-map-series": "1.0.0",
+				"tempfile": "2.0.0"
+			},
+			"dependencies": {
+				"execa": {
+					"version": "0.7.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+					"requires": {
+						"cross-spawn": "5.1.0",
+						"get-stream": "3.0.0",
+						"is-stream": "1.1.0",
+						"npm-run-path": "2.0.2",
+						"p-finally": "1.0.0",
+						"signal-exit": "3.0.2",
+						"strip-eof": "1.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+				}
+			}
+		},
+		"bin-check": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bin-check/-/bin-check-4.1.0.tgz",
+			"integrity": "sha512-b6weQyEUKsDGFlACWSIOfveEnImkJyK/FGW6FAG42loyoquvjdtOIqO6yBFzHyqyVVhNgNkQxxx09SFLK28YnA==",
+			"dev": true,
+			"requires": {
+				"execa": "0.7.0",
+				"executable": "4.1.0"
+			},
+			"dependencies": {
+				"execa": {
+					"version": "0.7.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "5.1.0",
+						"get-stream": "3.0.0",
+						"is-stream": "1.1.0",
+						"npm-run-path": "2.0.2",
+						"p-finally": "1.0.0",
+						"signal-exit": "3.0.2",
+						"strip-eof": "1.0.0"
+					}
+				},
+				"executable": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/executable/-/executable-4.1.0.tgz",
+					"integrity": "sha1-ldm0RRkBWYUpIP12//2W+Awf5Oc=",
+					"dev": true,
+					"requires": {
+						"pify": "2.3.0"
+					}
+				},
+				"get-stream": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+					"dev": true
+				}
+			}
+		},
+		"bin-version": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz",
+			"integrity": "sha1-nrSY7m/Xb3q5p8FgQ2+JV5Q1144=",
+			"requires": {
+				"find-versions": "1.2.1"
+			}
+		},
+		"bin-version-check": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-2.1.0.tgz",
+			"integrity": "sha1-5OXfKQuQaffRETJAMe/BP90RpbA=",
+			"requires": {
+				"bin-version": "1.0.4",
+				"minimist": "1.2.0",
+				"semver": "4.3.6",
+				"semver-truncate": "1.1.2"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "4.3.6",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+					"integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
+				}
+			}
+		},
+		"bin-wrapper": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-3.0.2.tgz",
+			"integrity": "sha1-Z9MwYmLksaXy+I7iNGT2plVneus=",
+			"requires": {
+				"bin-check": "2.0.0",
+				"bin-version-check": "2.1.0",
+				"download": "4.4.3",
+				"each-async": "1.1.1",
+				"lazy-req": "1.1.0",
+				"os-filter-obj": "1.0.3"
+			},
+			"dependencies": {
+				"bin-check": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/bin-check/-/bin-check-2.0.0.tgz",
+					"integrity": "sha1-hvjm9CU4k99g3DFpV/WvAqywWTA=",
+					"requires": {
+						"executable": "1.1.0"
+					}
+				},
+				"caw": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/caw/-/caw-1.2.0.tgz",
+					"integrity": "sha1-/7Im/n78VHKI3GLuPpcHPCEtEDQ=",
+					"requires": {
+						"get-proxy": "1.1.0",
+						"is-obj": "1.0.1",
+						"object-assign": "3.0.0",
+						"tunnel-agent": "0.4.3"
+					},
+					"dependencies": {
+						"object-assign": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+							"integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+						}
+					}
+				},
+				"download": {
+					"version": "4.4.3",
+					"resolved": "https://registry.npmjs.org/download/-/download-4.4.3.tgz",
+					"integrity": "sha1-qlX9rTktldS2jowr4D4MKqIbqaw=",
+					"requires": {
+						"caw": "1.2.0",
+						"concat-stream": "1.6.0",
+						"each-async": "1.1.1",
+						"filenamify": "1.2.1",
+						"got": "5.7.1",
+						"gulp-decompress": "1.2.0",
+						"gulp-rename": "1.2.2",
+						"is-url": "1.2.2",
+						"object-assign": "4.1.1",
+						"read-all-stream": "3.1.0",
+						"readable-stream": "2.3.3",
+						"stream-combiner2": "1.1.1",
+						"vinyl": "1.2.0",
+						"vinyl-fs": "2.4.4",
+						"ware": "1.3.0"
+					}
+				},
+				"filename-reserved-regex": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
+					"integrity": "sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q="
+				},
+				"filenamify": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz",
+					"integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
+					"requires": {
+						"filename-reserved-regex": "1.0.0",
+						"strip-outer": "1.0.0",
+						"trim-repeated": "1.0.0"
+					}
+				},
+				"get-proxy": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-1.1.0.tgz",
+					"integrity": "sha1-iUhUSRvFkbDxR9euVw9cZ4tyVus=",
+					"requires": {
+						"rc": "1.2.2"
+					}
+				},
+				"got": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
+					"integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
+					"requires": {
+						"create-error-class": "3.0.2",
+						"duplexer2": "0.1.4",
+						"is-redirect": "1.0.0",
+						"is-retry-allowed": "1.1.0",
+						"is-stream": "1.1.0",
+						"lowercase-keys": "1.0.0",
+						"node-status-codes": "1.0.0",
+						"object-assign": "4.1.1",
+						"parse-json": "2.2.0",
+						"pinkie-promise": "2.0.1",
+						"read-all-stream": "3.1.0",
+						"readable-stream": "2.3.3",
+						"timed-out": "3.1.3",
+						"unzip-response": "1.0.2",
+						"url-parse-lax": "1.0.0"
+					}
+				},
+				"timed-out": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
+					"integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc="
+				},
+				"tunnel-agent": {
+					"version": "0.4.3",
+					"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+					"integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+				}
+			}
+		},
+		"binary-extensions": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
+			"dev": true
+		},
+		"bl": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
+			"integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+			"requires": {
+				"readable-stream": "2.3.3"
+			}
+		},
+		"bluebird": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+			"dev": true
+		},
+		"boxen": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+			"integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+			"dev": true,
+			"requires": {
+				"ansi-align": "2.0.0",
+				"camelcase": "4.1.0",
+				"chalk": "2.3.0",
+				"cli-boxes": "1.0.0",
+				"string-width": "2.1.1",
+				"term-size": "1.2.0",
+				"widest-line": "2.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "4.5.0"
+					}
+				},
+				"supports-color": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+					"dev": true,
+					"requires": {
+						"has-flag": "2.0.0"
+					}
+				}
+			}
+		},
+		"brace-expansion": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+			"requires": {
+				"balanced-match": "1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"braces": {
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"requires": {
+				"expand-range": "1.8.2",
+				"preserve": "0.2.0",
+				"repeat-element": "1.1.2"
+			}
+		},
+		"buf-compare": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buf-compare/-/buf-compare-1.0.1.tgz",
+			"integrity": "sha1-/vKNqLgROgoNtEMLC2Rntpcws0o=",
+			"dev": true
+		},
+		"buffer": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+			"integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
+			"requires": {
+				"base64-js": "0.0.8",
+				"ieee754": "1.1.8",
+				"isarray": "1.0.0"
+			}
+		},
+		"buffer-crc32": {
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+		},
+		"buffer-to-vinyl": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/buffer-to-vinyl/-/buffer-to-vinyl-1.1.0.tgz",
+			"integrity": "sha1-APFfruOreh3aLN5tkSG//dB7ImI=",
+			"requires": {
+				"file-type": "3.9.0",
+				"readable-stream": "2.3.3",
+				"uuid": "2.0.3",
+				"vinyl": "1.2.0"
+			},
+			"dependencies": {
+				"file-type": {
+					"version": "3.9.0",
+					"resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+					"integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
+				},
+				"uuid": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+					"integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
+				}
+			}
+		},
+		"builtin-modules": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+		},
+		"caching-transform": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
+			"integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
+			"dev": true,
+			"requires": {
+				"md5-hex": "1.3.0",
+				"mkdirp": "0.5.1",
+				"write-file-atomic": "1.3.4"
+			},
+			"dependencies": {
+				"md5-hex": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
+					"integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+					"dev": true,
+					"requires": {
+						"md5-o-matic": "0.1.1"
+					}
+				},
+				"write-file-atomic": {
+					"version": "1.3.4",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+					"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"imurmurhash": "0.1.4",
+						"slide": "1.1.6"
+					}
+				}
+			}
+		},
+		"call-matcher": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/call-matcher/-/call-matcher-1.0.1.tgz",
+			"integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
+			"dev": true,
+			"requires": {
+				"core-js": "2.5.1",
+				"deep-equal": "1.0.1",
+				"espurify": "1.7.0",
+				"estraverse": "4.2.0"
+			}
+		},
+		"call-signature": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/call-signature/-/call-signature-0.0.2.tgz",
+			"integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY=",
+			"dev": true
+		},
+		"caller-path": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+			"dev": true,
+			"requires": {
+				"callsites": "0.2.0"
+			}
+		},
+		"callsites": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+			"integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+			"dev": true
+		},
+		"camelcase": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+			"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+		},
+		"camelcase-keys": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+			"requires": {
+				"camelcase": "2.1.1",
+				"map-obj": "1.0.1"
+			}
+		},
+		"capture-stack-trace": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+			"integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
+		},
+		"caw": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/caw/-/caw-2.0.1.tgz",
+			"integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
+			"requires": {
+				"get-proxy": "2.1.0",
+				"isurl": "1.0.0",
+				"tunnel-agent": "0.6.0",
+				"url-to-options": "1.0.1"
+			}
+		},
+		"chalk": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"requires": {
+				"ansi-styles": "2.2.1",
+				"escape-string-regexp": "1.0.5",
+				"has-ansi": "2.0.0",
+				"strip-ansi": "3.0.1",
+				"supports-color": "2.0.0"
+			}
+		},
+		"chokidar": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+			"dev": true,
+			"requires": {
+				"anymatch": "1.3.2",
+				"async-each": "1.0.1",
+				"glob-parent": "2.0.0",
+				"inherits": "2.0.3",
+				"is-binary-path": "1.0.1",
+				"is-glob": "2.0.1",
+				"path-is-absolute": "1.0.1",
+				"readdirp": "2.1.0"
+			},
+			"dependencies": {
+				"glob-parent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+					"dev": true,
+					"requires": {
+						"is-glob": "2.0.1"
+					}
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				}
+			}
+		},
+		"ci-info": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
+			"integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
+			"dev": true
+		},
+		"circular-json": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+			"dev": true
+		},
+		"clean-stack": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-1.3.0.tgz",
+			"integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE=",
+			"dev": true
+		},
+		"clean-yaml-object": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
+			"integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g=",
+			"dev": true
+		},
+		"cli-boxes": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+			"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+			"dev": true
+		},
+		"cli-cursor": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"dev": true,
+			"requires": {
+				"restore-cursor": "2.0.0"
+			}
+		},
+		"cli-spinners": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.1.0.tgz",
+			"integrity": "sha1-8YR7FohE2RemceudFH499JfJDQY=",
+			"dev": true
+		},
+		"cli-truncate": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-1.1.0.tgz",
+			"integrity": "sha512-bAtZo0u82gCfaAGfSNxUdTI9mNyza7D8w4CVCcaOsy7sgwDzvx6ekr6cuWJqY3UGzgnQ1+4wgENup5eIhgxEYA==",
+			"dev": true,
+			"requires": {
+				"slice-ansi": "1.0.0",
+				"string-width": "2.1.1"
+			}
+		},
+		"cli-width": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+			"dev": true
+		},
+		"clone": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+			"integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
+		},
+		"clone-stats": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+			"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+		},
+		"co": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
+			"integrity": "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g="
+		},
+		"co-with-promise": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co-with-promise/-/co-with-promise-4.6.0.tgz",
+			"integrity": "sha1-QT59tvWJOmC5Qs9JLEvsk9tBWrc=",
+			"dev": true,
+			"requires": {
+				"pinkie-promise": "1.0.0"
+			},
+			"dependencies": {
+				"pinkie": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
+					"integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q=",
+					"dev": true
+				},
+				"pinkie-promise": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+					"integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
+					"dev": true,
+					"requires": {
+						"pinkie": "1.0.0"
+					}
+				}
+			}
+		},
+		"code-excerpt": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-2.1.0.tgz",
+			"integrity": "sha1-XcwIHoj0p+O1VOnjXX7yMtR/gUc=",
+			"dev": true,
+			"requires": {
+				"convert-to-spaces": "1.0.2"
+			}
+		},
+		"code-point-at": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+			"dev": true
+		},
+		"color-convert": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+			"dev": true,
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
+		},
+		"commander": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+			"integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+			"requires": {
+				"graceful-readlink": "1.0.1"
+			}
+		},
+		"common-path-prefix": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-1.0.0.tgz",
+			"integrity": "sha1-zVL28HEuC6q5fW+XModPIvR3UsA=",
+			"dev": true
+		},
+		"commondir": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+			"dev": true
+		},
+		"compare-size": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/compare-size/-/compare-size-3.0.0.tgz",
+			"integrity": "sha1-6le0n6e8gyvj3fCJSja+K27Migw=",
+			"dev": true,
+			"requires": {
+				"pify": "2.3.0"
+			}
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"concat-stream": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+			"integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3",
+				"typedarray": "0.0.6"
+			}
+		},
+		"concordance": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/concordance/-/concordance-3.0.0.tgz",
+			"integrity": "sha512-CZBzJ3/l5QJjlZM20WY7+5GP5pMTw+1UEbThcpMw8/rojsi5sBCiD8ZbBLtD+jYpRGAkwuKuqk108c154V9eyQ==",
+			"dev": true,
+			"requires": {
+				"date-time": "2.1.0",
+				"esutils": "2.0.2",
+				"fast-diff": "1.1.2",
+				"function-name-support": "0.2.0",
+				"js-string-escape": "1.0.1",
+				"lodash.clonedeep": "4.5.0",
+				"lodash.flattendeep": "4.4.0",
+				"lodash.merge": "4.6.0",
+				"md5-hex": "2.0.0",
+				"semver": "5.4.1",
+				"well-known-symbols": "1.0.0"
+			}
+		},
+		"config-chain": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
+			"integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
+			"requires": {
+				"ini": "1.3.5",
+				"proto-list": "1.2.4"
+			}
+		},
+		"configstore": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
+			"integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
+			"dev": true,
+			"requires": {
+				"dot-prop": "4.2.0",
+				"graceful-fs": "4.1.11",
+				"make-dir": "1.1.0",
+				"unique-string": "1.0.0",
+				"write-file-atomic": "2.3.0",
+				"xdg-basedir": "3.0.0"
+			}
+		},
+		"console-stream": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/console-stream/-/console-stream-0.1.1.tgz",
+			"integrity": "sha1-oJX+B7IEZZVfL6/Si11yvM2UnUQ="
+		},
+		"contains-path": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+			"dev": true
+		},
+		"content-disposition": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+		},
+		"convert-source-map": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+		},
+		"convert-to-spaces": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-1.0.2.tgz",
+			"integrity": "sha1-fj5Iu+bZl7FBfdyihoIEtNPYVxU=",
+			"dev": true
+		},
+		"core-assert": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/core-assert/-/core-assert-0.2.1.tgz",
+			"integrity": "sha1-+F4s+b/tKPdzzIs/pcW2m9wC/j8=",
+			"dev": true,
+			"requires": {
+				"buf-compare": "1.0.1",
+				"is-error": "2.2.1"
+			}
+		},
+		"core-js": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+			"integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+			"dev": true
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+		},
+		"create-error-class": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+			"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+			"requires": {
+				"capture-stack-trace": "1.0.0"
+			}
+		},
+		"cross-spawn": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+			"requires": {
+				"lru-cache": "4.1.1",
+				"shebang-command": "1.2.0",
+				"which": "1.3.0"
+			}
+		},
+		"crypto-random-string": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+			"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+			"dev": true
+		},
+		"currently-unhandled": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+			"requires": {
+				"array-find-index": "1.0.2"
+			}
+		},
+		"d": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+			"dev": true,
+			"requires": {
+				"es5-ext": "0.10.37"
+			}
+		},
+		"date-time": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/date-time/-/date-time-2.1.0.tgz",
+			"integrity": "sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==",
+			"dev": true,
+			"requires": {
+				"time-zone": "1.0.0"
+			}
+		},
+		"dateformat": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+			"integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
+		},
+		"debug": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"dev": true,
+			"requires": {
+				"ms": "2.0.0"
+			},
+			"dependencies": {
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				}
+			}
+		},
+		"decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+		},
+		"decompress": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
+			"integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
+			"requires": {
+				"decompress-tar": "4.1.1",
+				"decompress-tarbz2": "4.1.1",
+				"decompress-targz": "4.1.1",
+				"decompress-unzip": "4.0.1",
+				"graceful-fs": "4.1.11",
+				"make-dir": "1.1.0",
+				"pify": "2.3.0",
+				"strip-dirs": "2.1.0"
+			}
+		},
+		"decompress-response": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+			"requires": {
+				"mimic-response": "1.0.0"
+			}
+		},
+		"decompress-tar": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
+			"integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
+			"requires": {
+				"file-type": "5.2.0",
+				"is-stream": "1.1.0",
+				"tar-stream": "1.5.5"
+			}
+		},
+		"decompress-tarbz2": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
+			"integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
+			"requires": {
+				"decompress-tar": "4.1.1",
+				"file-type": "6.2.0",
+				"is-stream": "1.1.0",
+				"seek-bzip": "1.0.5",
+				"unbzip2-stream": "1.2.5"
+			},
+			"dependencies": {
+				"file-type": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
+					"integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg=="
+				}
+			}
+		},
+		"decompress-targz": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
+			"integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
+			"requires": {
+				"decompress-tar": "4.1.1",
+				"file-type": "5.2.0",
+				"is-stream": "1.1.0"
+			}
+		},
+		"decompress-unzip": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
+			"integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
+			"requires": {
+				"file-type": "3.9.0",
+				"get-stream": "2.3.1",
+				"pify": "2.3.0",
+				"yauzl": "2.9.1"
+			},
+			"dependencies": {
+				"file-type": {
+					"version": "3.9.0",
+					"resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+					"integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
+				}
+			}
+		},
+		"deep-assign": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
+			"integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
+			"dev": true,
+			"requires": {
+				"is-obj": "1.0.1"
+			}
+		},
+		"deep-equal": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+			"integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+			"dev": true
+		},
+		"deep-extend": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+			"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+		},
+		"deep-is": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
+		},
+		"deep-strict-equal": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/deep-strict-equal/-/deep-strict-equal-0.2.0.tgz",
+			"integrity": "sha1-SgeBR6irV/ag1PVUckPNIvROtOQ=",
+			"dev": true,
+			"requires": {
+				"core-assert": "0.2.1"
+			}
+		},
+		"del": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+			"dev": true,
+			"requires": {
+				"globby": "5.0.0",
+				"is-path-cwd": "1.0.0",
+				"is-path-in-cwd": "1.0.0",
+				"object-assign": "4.1.1",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"rimraf": "2.6.2"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"globby": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+					"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+					"dev": true,
+					"requires": {
+						"array-union": "1.0.2",
+						"arrify": "1.0.1",
+						"glob": "7.1.2",
+						"object-assign": "4.1.1",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
+					}
+				}
+			}
+		},
+		"detect-indent": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+			"dev": true,
+			"requires": {
+				"repeating": "2.0.1"
+			}
+		},
+		"doctrine": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.2.tgz",
+			"integrity": "sha512-y0tm5Pq6ywp3qSTZ1vPgVdAnbDEoeoc5wlOHXoY1c4Wug/a7JvqHIl7BTvwodaHmejWkK/9dSb3sCYfyo/om8A==",
+			"dev": true,
+			"requires": {
+				"esutils": "2.0.2"
+			}
+		},
+		"dot-prop": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+			"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+			"dev": true,
+			"requires": {
+				"is-obj": "1.0.1"
+			}
+		},
+		"download": {
+			"version": "6.2.5",
+			"resolved": "https://registry.npmjs.org/download/-/download-6.2.5.tgz",
+			"integrity": "sha512-DpO9K1sXAST8Cpzb7kmEhogJxymyVUd5qz/vCOSyvwtp2Klj2XcDt5YUuasgxka44SxF0q5RriKIwJmQHG2AuA==",
+			"requires": {
+				"caw": "2.0.1",
+				"content-disposition": "0.5.2",
+				"decompress": "4.2.0",
+				"ext-name": "5.0.0",
+				"file-type": "5.2.0",
+				"filenamify": "2.0.0",
+				"get-stream": "3.0.0",
+				"got": "7.1.0",
+				"make-dir": "1.1.0",
+				"p-event": "1.3.0",
+				"pify": "3.0.0"
+			},
+			"dependencies": {
+				"get-stream": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
+			}
+		},
+		"duplexer2": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+			"integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+			"requires": {
+				"readable-stream": "2.3.3"
+			}
+		},
+		"duplexer3": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+		},
+		"duplexify": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
+			"integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
+			"requires": {
+				"end-of-stream": "1.4.0",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3",
+				"stream-shift": "1.0.0"
+			}
+		},
+		"each-async": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
+			"integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
+			"requires": {
+				"onetime": "1.1.0",
+				"set-immediate-shim": "1.0.1"
+			}
+		},
+		"empower-core": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/empower-core/-/empower-core-0.6.2.tgz",
+			"integrity": "sha1-Wt71ZgiOMfuoC6CjbfR9cJQWkUQ=",
+			"dev": true,
+			"requires": {
+				"call-signature": "0.0.2",
+				"core-js": "2.5.1"
+			}
+		},
+		"end-of-stream": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+			"integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+			"requires": {
+				"once": "1.4.0"
+			}
+		},
+		"enhance-visitors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/enhance-visitors/-/enhance-visitors-1.0.0.tgz",
+			"integrity": "sha1-qpRdBdpGVnKh69OP7i7T2oUY6Vo=",
+			"dev": true,
+			"requires": {
+				"lodash": "4.17.4"
+			}
+		},
+		"equal-length": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/equal-length/-/equal-length-1.0.1.tgz",
+			"integrity": "sha1-IcoRLUirJLTh5//A5TOdMf38J0w=",
+			"dev": true
+		},
+		"error-ex": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+			"requires": {
+				"is-arrayish": "0.2.1"
+			}
+		},
+		"es5-ext": {
+			"version": "0.10.37",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.37.tgz",
+			"integrity": "sha1-DudB0Ui4AGm6J9AgOTdWryV978M=",
+			"dev": true,
+			"requires": {
+				"es6-iterator": "2.0.3",
+				"es6-symbol": "3.1.1"
+			}
+		},
+		"es6-error": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.0.2.tgz",
+			"integrity": "sha1-7sXHJurO9Rt/a3PCDbbhsTsGnJg=",
+			"dev": true
+		},
+		"es6-iterator": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+			"dev": true,
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.37",
+				"es6-symbol": "3.1.1"
+			}
+		},
+		"es6-map": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+			"integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+			"dev": true,
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.37",
+				"es6-iterator": "2.0.3",
+				"es6-set": "0.1.5",
+				"es6-symbol": "3.1.1",
+				"event-emitter": "0.3.5"
+			}
+		},
+		"es6-set": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+			"integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+			"dev": true,
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.37",
+				"es6-iterator": "2.0.3",
+				"es6-symbol": "3.1.1",
+				"event-emitter": "0.3.5"
+			}
+		},
+		"es6-symbol": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+			"dev": true,
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.37"
+			}
+		},
+		"es6-weak-map": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+			"integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+			"dev": true,
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.37",
+				"es6-iterator": "2.0.3",
+				"es6-symbol": "3.1.1"
+			}
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"escope": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+			"integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+			"dev": true,
+			"requires": {
+				"es6-map": "0.1.5",
+				"es6-weak-map": "2.0.2",
+				"esrecurse": "4.2.0",
+				"estraverse": "4.2.0"
+			}
+		},
+		"eslint": {
+			"version": "3.19.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
+			"integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
+			"dev": true,
+			"requires": {
+				"babel-code-frame": "6.26.0",
+				"chalk": "1.1.3",
+				"concat-stream": "1.6.0",
+				"debug": "2.6.9",
+				"doctrine": "2.0.2",
+				"escope": "3.6.0",
+				"espree": "3.5.2",
+				"esquery": "1.0.0",
+				"estraverse": "4.2.0",
+				"esutils": "2.0.2",
+				"file-entry-cache": "2.0.0",
+				"glob": "7.1.2",
+				"globals": "9.18.0",
+				"ignore": "3.3.7",
+				"imurmurhash": "0.1.4",
+				"inquirer": "0.12.0",
+				"is-my-json-valid": "2.16.1",
+				"is-resolvable": "1.0.0",
+				"js-yaml": "3.10.0",
+				"json-stable-stringify": "1.0.1",
+				"levn": "0.3.0",
+				"lodash": "4.17.4",
+				"mkdirp": "0.5.1",
+				"natural-compare": "1.4.0",
+				"optionator": "0.8.2",
+				"path-is-inside": "1.0.2",
+				"pluralize": "1.2.1",
+				"progress": "1.1.8",
+				"require-uncached": "1.0.3",
+				"shelljs": "0.7.8",
+				"strip-bom": "3.0.0",
+				"strip-json-comments": "2.0.1",
+				"table": "3.8.3",
+				"text-table": "0.2.0",
+				"user-home": "2.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+					"dev": true
+				}
+			}
+		},
+		"eslint-config-xo": {
+			"version": "0.18.2",
+			"resolved": "https://registry.npmjs.org/eslint-config-xo/-/eslint-config-xo-0.18.2.tgz",
+			"integrity": "sha1-ChVxIIdWGZKec1/9axhcQeihh68=",
+			"dev": true
+		},
+		"eslint-formatter-pretty": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-1.3.0.tgz",
+			"integrity": "sha512-5DY64Y1rYCm7cfFDHEGUn54bvCnK+wSUVF07N8oXeqUJFSd+gnYOTXbzelQ1HurESluY6gnEQPmXOIkB4Wa+gA==",
+			"dev": true,
+			"requires": {
+				"ansi-escapes": "2.0.0",
+				"chalk": "2.3.0",
+				"log-symbols": "2.1.0",
+				"plur": "2.1.2",
+				"string-width": "2.1.1"
+			},
+			"dependencies": {
+				"ansi-escapes": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
+					"integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "4.5.0"
+					}
+				},
+				"supports-color": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+					"dev": true,
+					"requires": {
+						"has-flag": "2.0.0"
+					}
+				}
+			}
+		},
+		"eslint-import-resolver-node": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz",
+			"integrity": "sha512-yUtXS15gIcij68NmXmP9Ni77AQuCN0itXbCc/jWd8C6/yKZaSNXicpC8cgvjnxVdmfsosIXrjpzFq7GcDryb6A==",
+			"dev": true,
+			"requires": {
+				"debug": "2.6.9",
+				"resolve": "1.5.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				}
+			}
+		},
+		"eslint-module-utils": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
+			"integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
+			"dev": true,
+			"requires": {
+				"debug": "2.6.9",
+				"pkg-dir": "1.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+					"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+					"dev": true,
+					"requires": {
+						"find-up": "1.1.2"
+					}
+				}
+			}
+		},
+		"eslint-plugin-ava": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-4.3.0.tgz",
+			"integrity": "sha1-XRUggk2WpRC75Orw8S/jXyBKdJ4=",
+			"dev": true,
+			"requires": {
+				"arrify": "1.0.1",
+				"deep-strict-equal": "0.2.0",
+				"enhance-visitors": "1.0.0",
+				"espree": "3.5.2",
+				"espurify": "1.7.0",
+				"import-modules": "1.1.0",
+				"multimatch": "2.1.0",
+				"pkg-up": "2.0.0"
+			}
+		},
+		"eslint-plugin-import": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz",
+			"integrity": "sha512-Rf7dfKJxZ16QuTgVv1OYNxkZcsu/hULFnC+e+w0Gzi6jMC3guQoWQgxYxc54IDRinlb6/0v5z/PxxIKmVctN+g==",
+			"dev": true,
+			"requires": {
+				"builtin-modules": "1.1.1",
+				"contains-path": "0.1.0",
+				"debug": "2.6.9",
+				"doctrine": "1.5.0",
+				"eslint-import-resolver-node": "0.3.1",
+				"eslint-module-utils": "2.1.1",
+				"has": "1.0.1",
+				"lodash.cond": "4.5.2",
+				"minimatch": "3.0.4",
+				"read-pkg-up": "2.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"doctrine": {
+					"version": "1.5.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+					"dev": true,
+					"requires": {
+						"esutils": "2.0.2",
+						"isarray": "1.0.0"
+					}
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
+					"requires": {
+						"locate-path": "2.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"strip-bom": "3.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				},
+				"path-type": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+					"dev": true,
+					"requires": {
+						"pify": "2.3.0"
+					}
+				},
+				"read-pkg": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "2.0.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "2.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+					"dev": true,
+					"requires": {
+						"find-up": "2.1.0",
+						"read-pkg": "2.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+					"dev": true
+				}
+			}
+		},
+		"eslint-plugin-no-use-extend-native": {
+			"version": "0.3.12",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-no-use-extend-native/-/eslint-plugin-no-use-extend-native-0.3.12.tgz",
+			"integrity": "sha1-OtmgDC3yO11/f2vpFVCYWkq3Aeo=",
+			"dev": true,
+			"requires": {
+				"is-get-set-prop": "1.0.0",
+				"is-js-type": "2.0.0",
+				"is-obj-prop": "1.0.0",
+				"is-proto-prop": "1.0.0"
+			}
+		},
+		"eslint-plugin-promise": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.6.0.tgz",
+			"integrity": "sha512-YQzM6TLTlApAr7Li8vWKR+K3WghjwKcYzY0d2roWap4SLK+kzuagJX/leTetIDWsFcTFnKNJXWupDCD6aZkP2Q==",
+			"dev": true
+		},
+		"eslint-plugin-unicorn": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-2.1.2.tgz",
+			"integrity": "sha1-md/+n0dzsEvDk1an/r1k3XACdLw=",
+			"dev": true,
+			"requires": {
+				"import-modules": "1.1.0",
+				"lodash.camelcase": "4.3.0",
+				"lodash.kebabcase": "4.1.1",
+				"lodash.snakecase": "4.1.1",
+				"lodash.upperfirst": "4.3.1"
+			}
+		},
+		"espower-location-detector": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/espower-location-detector/-/espower-location-detector-1.0.0.tgz",
+			"integrity": "sha1-oXt+zFnTDheeK+9z+0E3cEyzMbU=",
+			"dev": true,
+			"requires": {
+				"is-url": "1.2.2",
+				"path-is-absolute": "1.0.1",
+				"source-map": "0.5.7",
+				"xtend": "4.0.1"
+			}
+		},
+		"espree": {
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
+			"integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
+			"dev": true,
+			"requires": {
+				"acorn": "5.2.1",
+				"acorn-jsx": "3.0.1"
+			}
+		},
+		"esprima": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+			"dev": true
+		},
+		"espurify": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/espurify/-/espurify-1.7.0.tgz",
+			"integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
+			"dev": true,
+			"requires": {
+				"core-js": "2.5.1"
+			}
+		},
+		"esquery": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+			"integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+			"dev": true,
+			"requires": {
+				"estraverse": "4.2.0"
+			}
+		},
+		"esrecurse": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+			"integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+			"dev": true,
+			"requires": {
+				"estraverse": "4.2.0",
+				"object-assign": "4.1.1"
+			}
+		},
+		"estraverse": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"dev": true
+		},
+		"esutils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
+		},
+		"event-emitter": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+			"integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+			"dev": true,
+			"requires": {
+				"d": "1.0.0",
+				"es5-ext": "0.10.37"
+			}
+		},
+		"execa": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+			"integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+			"requires": {
+				"cross-spawn": "5.1.0",
+				"get-stream": "3.0.0",
+				"is-stream": "1.1.0",
+				"npm-run-path": "2.0.2",
+				"p-finally": "1.0.0",
+				"signal-exit": "3.0.2",
+				"strip-eof": "1.0.0"
+			},
+			"dependencies": {
+				"get-stream": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+				}
+			}
+		},
+		"executable": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/executable/-/executable-1.1.0.tgz",
+			"integrity": "sha1-h3mA6REvM5EGbaNyZd562ENKtNk=",
+			"requires": {
+				"meow": "3.7.0"
+			}
+		},
+		"exit-hook": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+			"integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+			"dev": true
+		},
+		"expand-brackets": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"requires": {
+				"is-posix-bracket": "0.1.1"
+			}
+		},
+		"expand-range": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"requires": {
+				"fill-range": "2.2.3"
+			}
+		},
+		"ext-list": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
+			"integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
+			"requires": {
+				"mime-db": "1.32.0"
+			}
+		},
+		"ext-name": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
+			"integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
+			"requires": {
+				"ext-list": "2.2.2",
+				"sort-keys-length": "1.0.1"
+			}
+		},
+		"extend": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+		},
+		"extend-shallow": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+			"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+			"requires": {
+				"is-extendable": "0.1.1"
+			}
+		},
+		"extglob": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"requires": {
+				"is-extglob": "1.0.0"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				}
+			}
+		},
+		"fancy-log": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+			"integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
+			"requires": {
+				"chalk": "1.1.3",
+				"time-stamp": "1.1.0"
+			}
+		},
+		"fast-diff": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+			"integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+			"dev": true
+		},
+		"fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
+		},
+		"fd-slicer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+			"integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+			"requires": {
+				"pend": "1.2.0"
+			}
+		},
+		"figures": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+			"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+			"requires": {
+				"escape-string-regexp": "1.0.5",
+				"object-assign": "4.1.1"
+			}
+		},
+		"file-entry-cache": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+			"dev": true,
+			"requires": {
+				"flat-cache": "1.3.0",
+				"object-assign": "4.1.1"
+			}
+		},
+		"file-type": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+			"integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
+		},
+		"filename-regex": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+		},
+		"filename-reserved-regex": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+			"integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik="
+		},
+		"filenamify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.0.0.tgz",
+			"integrity": "sha1-vRYiYsC26Uv7zc8Zo7uzdk94VpU=",
+			"requires": {
+				"filename-reserved-regex": "2.0.0",
+				"strip-outer": "1.0.0",
+				"trim-repeated": "1.0.0"
+			}
+		},
+		"fill-range": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+			"requires": {
+				"is-number": "2.1.0",
+				"isobject": "2.1.0",
+				"randomatic": "1.1.7",
+				"repeat-element": "1.1.2",
+				"repeat-string": "1.6.1"
+			}
+		},
+		"find-cache-dir": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+			"dev": true,
+			"requires": {
+				"commondir": "1.0.1",
+				"make-dir": "1.1.0",
+				"pkg-dir": "2.0.0"
+			}
+		},
+		"find-up": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+			"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+			"requires": {
+				"path-exists": "2.1.0",
+				"pinkie-promise": "2.0.1"
+			}
+		},
+		"find-versions": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/find-versions/-/find-versions-1.2.1.tgz",
+			"integrity": "sha1-y96fEuOFdaCvG+G5osXV/Y8Ya2I=",
+			"requires": {
+				"array-uniq": "1.0.3",
+				"get-stdin": "4.0.1",
+				"meow": "3.7.0",
+				"semver-regex": "1.0.0"
+			}
+		},
+		"first-chunk-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+			"integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04="
+		},
+		"flat-cache": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+			"dev": true,
+			"requires": {
+				"circular-json": "0.3.3",
+				"del": "2.2.2",
+				"graceful-fs": "4.1.11",
+				"write": "0.2.1"
+			}
+		},
+		"fn-name": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
+			"integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=",
+			"dev": true
+		},
+		"for-in": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+		},
+		"for-own": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"requires": {
+				"for-in": "1.0.2"
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
+		},
+		"function-name-support": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/function-name-support/-/function-name-support-0.2.0.tgz",
+			"integrity": "sha1-VdO/qm6v1QWlD5vIH99XVkoLsHE=",
+			"dev": true
+		},
+		"generate-function": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+			"integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+			"dev": true
+		},
+		"generate-object-property": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+			"integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+			"dev": true,
+			"requires": {
+				"is-property": "1.0.2"
+			}
+		},
+		"get-port": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
+			"integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
+			"dev": true
+		},
+		"get-proxy": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz",
+			"integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
+			"requires": {
+				"npm-conf": "1.1.3"
+			}
+		},
+		"get-set-props": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/get-set-props/-/get-set-props-0.1.0.tgz",
+			"integrity": "sha1-mYR1wXhEVobQsyJG2l3428++jqM=",
+			"dev": true
+		},
+		"get-stdin": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+		},
+		"get-stream": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+			"integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
+			"requires": {
+				"object-assign": "4.1.1",
+				"pinkie-promise": "2.0.1"
+			}
+		},
+		"glob": {
+			"version": "5.0.15",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+			"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+			"requires": {
+				"inflight": "1.0.6",
+				"inherits": "2.0.3",
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
+			}
+		},
+		"glob-base": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"requires": {
+				"glob-parent": "2.0.0",
+				"is-glob": "2.0.1"
+			},
+			"dependencies": {
+				"glob-parent": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+					"requires": {
+						"is-glob": "2.0.1"
+					}
+				},
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				}
+			}
+		},
+		"glob-parent": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+			"requires": {
+				"is-glob": "3.1.0",
+				"path-dirname": "1.0.2"
+			}
+		},
+		"glob-stream": {
+			"version": "5.3.5",
+			"resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
+			"integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
+			"requires": {
+				"extend": "3.0.1",
+				"glob": "5.0.15",
+				"glob-parent": "3.1.0",
+				"micromatch": "2.3.11",
+				"ordered-read-streams": "0.3.0",
+				"through2": "0.6.5",
+				"to-absolute-glob": "0.1.1",
+				"unique-stream": "2.2.1"
+			}
+		},
+		"global-dirs": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+			"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+			"dev": true,
+			"requires": {
+				"ini": "1.3.5"
+			}
+		},
+		"globals": {
+			"version": "9.18.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+			"dev": true
+		},
+		"globby": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+			"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+			"dev": true,
+			"requires": {
+				"array-union": "1.0.2",
+				"glob": "7.1.2",
+				"object-assign": "4.1.1",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				}
+			}
+		},
+		"glogg": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
+			"integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
+			"requires": {
+				"sparkles": "1.0.0"
+			}
+		},
+		"got": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+			"integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+			"requires": {
+				"decompress-response": "3.3.0",
+				"duplexer3": "0.1.4",
+				"get-stream": "3.0.0",
+				"is-plain-obj": "1.1.0",
+				"is-retry-allowed": "1.1.0",
+				"is-stream": "1.1.0",
+				"isurl": "1.0.0",
+				"lowercase-keys": "1.0.0",
+				"p-cancelable": "0.3.0",
+				"p-timeout": "1.2.1",
+				"safe-buffer": "5.1.1",
+				"timed-out": "4.0.1",
+				"url-parse-lax": "1.0.0",
+				"url-to-options": "1.0.1"
+			},
+			"dependencies": {
+				"get-stream": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+				}
+			}
+		},
+		"graceful-fs": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+		},
+		"graceful-readlink": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+			"integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+		},
+		"gulp-decompress": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.2.0.tgz",
+			"integrity": "sha1-jutlpeAV+O2FMsr+KEVJYGJvDcc=",
+			"requires": {
+				"archive-type": "3.2.0",
+				"decompress": "3.0.0",
+				"gulp-util": "3.0.8",
+				"readable-stream": "2.3.3"
+			},
+			"dependencies": {
+				"clone": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+					"integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
+				},
+				"decompress": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/decompress/-/decompress-3.0.0.tgz",
+					"integrity": "sha1-rx3VDQbjv8QyRh033hGzjA2ZG+0=",
+					"requires": {
+						"buffer-to-vinyl": "1.1.0",
+						"concat-stream": "1.6.0",
+						"decompress-tar": "3.1.0",
+						"decompress-tarbz2": "3.1.0",
+						"decompress-targz": "3.1.0",
+						"decompress-unzip": "3.4.0",
+						"stream-combiner2": "1.1.1",
+						"vinyl-assign": "1.2.1",
+						"vinyl-fs": "2.4.4"
+					}
+				},
+				"decompress-tar": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz",
+					"integrity": "sha1-IXx4n5uURQ76rcXF5TeXj8MzxGY=",
+					"requires": {
+						"is-tar": "1.0.0",
+						"object-assign": "2.1.1",
+						"strip-dirs": "1.1.1",
+						"tar-stream": "1.5.5",
+						"through2": "0.6.5",
+						"vinyl": "0.4.6"
+					}
+				},
+				"decompress-tarbz2": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz",
+					"integrity": "sha1-iyOTVoE1X58YnYclag+L3ZbZZm0=",
+					"requires": {
+						"is-bzip2": "1.0.0",
+						"object-assign": "2.1.1",
+						"seek-bzip": "1.0.5",
+						"strip-dirs": "1.1.1",
+						"tar-stream": "1.5.5",
+						"through2": "0.6.5",
+						"vinyl": "0.4.6"
+					}
+				},
+				"decompress-targz": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz",
+					"integrity": "sha1-ssE9+YFmJomRtxXWRH9kLpaW9aA=",
+					"requires": {
+						"is-gzip": "1.0.0",
+						"object-assign": "2.1.1",
+						"strip-dirs": "1.1.1",
+						"tar-stream": "1.5.5",
+						"through2": "0.6.5",
+						"vinyl": "0.4.6"
+					}
+				},
+				"decompress-unzip": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.4.0.tgz",
+					"integrity": "sha1-YUdbQVIGa74/7hL51inRX+ZHjus=",
+					"requires": {
+						"is-zip": "1.0.0",
+						"read-all-stream": "3.1.0",
+						"stat-mode": "0.2.2",
+						"strip-dirs": "1.1.1",
+						"through2": "2.0.3",
+						"vinyl": "1.2.0",
+						"yauzl": "2.9.1"
+					},
+					"dependencies": {
+						"clone": {
+							"version": "1.0.3",
+							"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+							"integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
+						},
+						"through2": {
+							"version": "2.0.3",
+							"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+							"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+							"requires": {
+								"readable-stream": "2.3.3",
+								"xtend": "4.0.1"
+							}
+						},
+						"vinyl": {
+							"version": "1.2.0",
+							"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+							"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+							"requires": {
+								"clone": "1.0.3",
+								"clone-stats": "0.0.1",
+								"replace-ext": "0.0.1"
+							}
+						}
+					}
+				},
+				"is-natural-number": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.1.1.tgz",
+					"integrity": "sha1-fUxXKDd+84bD4ZSpkRv1fG3DNec="
+				},
+				"object-assign": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+					"integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
+				},
+				"strip-dirs": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+					"integrity": "sha1-lgu9EoeETzl1pFWKoQOoJV4kVqA=",
+					"requires": {
+						"chalk": "1.1.3",
+						"get-stdin": "4.0.1",
+						"is-absolute": "0.1.7",
+						"is-natural-number": "2.1.1",
+						"minimist": "1.2.0",
+						"sum-up": "1.0.3"
+					}
+				},
+				"vinyl": {
+					"version": "0.4.6",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+					"integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+					"requires": {
+						"clone": "0.2.0",
+						"clone-stats": "0.0.1"
+					}
+				}
+			}
+		},
+		"gulp-rename": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz",
+			"integrity": "sha1-OtRCh2PwXidk3sHGfYaNsnVoeBc="
+		},
+		"gulp-sourcemaps": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+			"integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
+			"requires": {
+				"convert-source-map": "1.5.1",
+				"graceful-fs": "4.1.11",
+				"strip-bom": "2.0.0",
+				"through2": "2.0.3",
+				"vinyl": "1.2.0"
+			},
+			"dependencies": {
+				"through2": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+					"requires": {
+						"readable-stream": "2.3.3",
+						"xtend": "4.0.1"
+					}
+				}
+			}
+		},
+		"gulp-util": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+			"integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+			"requires": {
+				"array-differ": "1.0.0",
+				"array-uniq": "1.0.3",
+				"beeper": "1.1.1",
+				"chalk": "1.1.3",
+				"dateformat": "2.2.0",
+				"fancy-log": "1.3.0",
+				"gulplog": "1.0.0",
+				"has-gulplog": "0.1.0",
+				"lodash._reescape": "3.0.0",
+				"lodash._reevaluate": "3.0.0",
+				"lodash._reinterpolate": "3.0.0",
+				"lodash.template": "3.6.2",
+				"minimist": "1.2.0",
+				"multipipe": "0.1.2",
+				"object-assign": "3.0.0",
+				"replace-ext": "0.0.1",
+				"through2": "2.0.3",
+				"vinyl": "0.5.3"
+			},
+			"dependencies": {
+				"object-assign": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+					"integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+				},
+				"through2": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+					"requires": {
+						"readable-stream": "2.3.3",
+						"xtend": "4.0.1"
+					}
+				},
+				"vinyl": {
+					"version": "0.5.3",
+					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+					"integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+					"requires": {
+						"clone": "1.0.3",
+						"clone-stats": "0.0.1",
+						"replace-ext": "0.0.1"
+					}
+				}
+			}
+		},
+		"gulplog": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+			"integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+			"requires": {
+				"glogg": "1.0.0"
+			}
+		},
+		"has": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+			"dev": true,
+			"requires": {
+				"function-bind": "1.1.1"
+			}
+		},
+		"has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"requires": {
+				"ansi-regex": "2.1.1"
+			}
+		},
+		"has-color": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+			"integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
+			"dev": true
+		},
+		"has-flag": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+			"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+			"dev": true
+		},
+		"has-gulplog": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+			"integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+			"requires": {
+				"sparkles": "1.0.0"
+			}
+		},
+		"has-symbol-support-x": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.1.tgz",
+			"integrity": "sha512-JkaetveU7hFbqnAC1EV1sF4rlojU2D4Usc5CmS69l6NfmPDnpnFUegzFg33eDkkpNCxZ0mQp65HwUDrNFS/8MA=="
+		},
+		"has-to-string-tag-x": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+			"integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+			"requires": {
+				"has-symbol-support-x": "1.4.1"
+			}
+		},
+		"has-yarn": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-1.0.0.tgz",
+			"integrity": "sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac=",
+			"dev": true
+		},
+		"home-or-tmp": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+			"dev": true,
+			"requires": {
+				"os-homedir": "1.0.2",
+				"os-tmpdir": "1.0.2"
+			}
+		},
+		"hosted-git-info": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+			"integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+		},
+		"hullabaloo-config-manager": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/hullabaloo-config-manager/-/hullabaloo-config-manager-1.1.1.tgz",
+			"integrity": "sha512-ztKnkZV0TmxnumCDHHgLGNiDnotu4EHCp9YMkznWuo4uTtCyJ+cu+RNcxUeXYKTllpvLFWnbfWry09yzszgg+A==",
+			"dev": true,
+			"requires": {
+				"dot-prop": "4.2.0",
+				"es6-error": "4.0.2",
+				"graceful-fs": "4.1.11",
+				"indent-string": "3.2.0",
+				"json5": "0.5.1",
+				"lodash.clonedeep": "4.5.0",
+				"lodash.clonedeepwith": "4.5.0",
+				"lodash.isequal": "4.5.0",
+				"lodash.merge": "4.6.0",
+				"md5-hex": "2.0.0",
+				"package-hash": "2.0.0",
+				"pkg-dir": "2.0.0",
+				"resolve-from": "3.0.0",
+				"safe-buffer": "5.1.1"
+			},
+			"dependencies": {
+				"indent-string": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+					"dev": true
+				}
+			}
+		},
+		"ieee754": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+			"integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+		},
+		"ignore": {
+			"version": "3.3.7",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+			"integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+			"dev": true
+		},
+		"ignore-by-default": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+			"integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
+			"dev": true
+		},
+		"import-lazy": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+			"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+			"dev": true
+		},
+		"import-local": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-0.1.1.tgz",
+			"integrity": "sha1-sReVcqrNwRxqkQCftDDbyrX2aKg=",
+			"dev": true,
+			"requires": {
+				"pkg-dir": "2.0.0",
+				"resolve-cwd": "2.0.0"
+			}
+		},
+		"import-modules": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/import-modules/-/import-modules-1.1.0.tgz",
+			"integrity": "sha1-dI23nFzEK7lwHvq0JPiU5yYA6dw=",
+			"dev": true
+		},
+		"imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
+		},
+		"indent-string": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+			"requires": {
+				"repeating": "2.0.1"
+			}
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"requires": {
+				"once": "1.4.0",
+				"wrappy": "1.0.2"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+		},
+		"ini": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+		},
+		"inquirer": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+			"integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+			"dev": true,
+			"requires": {
+				"ansi-escapes": "1.4.0",
+				"ansi-regex": "2.1.1",
+				"chalk": "1.1.3",
+				"cli-cursor": "1.0.2",
+				"cli-width": "2.2.0",
+				"figures": "1.7.0",
+				"lodash": "4.17.4",
+				"readline2": "1.0.1",
+				"run-async": "0.1.0",
+				"rx-lite": "3.1.2",
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1",
+				"through": "2.3.8"
+			},
+			"dependencies": {
+				"ansi-escapes": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+					"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+					"dev": true
+				},
+				"cli-cursor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+					"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+					"dev": true,
+					"requires": {
+						"restore-cursor": "1.0.1"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"restore-cursor": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+					"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+					"dev": true,
+					"requires": {
+						"exit-hook": "1.1.1",
+						"onetime": "1.1.0"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				}
+			}
+		},
+		"interpret": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+			"integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+			"dev": true
+		},
+		"invariant": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+			"integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+			"dev": true,
+			"requires": {
+				"loose-envify": "1.3.1"
+			}
+		},
+		"irregular-plurals": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
+			"integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=",
+			"dev": true
+		},
+		"is-absolute": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+			"integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
+			"requires": {
+				"is-relative": "0.1.3"
+			}
+		},
+		"is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+		},
+		"is-binary-path": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+			"dev": true,
+			"requires": {
+				"binary-extensions": "1.11.0"
+			}
+		},
+		"is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+		},
+		"is-builtin-module": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+			"requires": {
+				"builtin-modules": "1.1.1"
+			}
+		},
+		"is-bzip2": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz",
+			"integrity": "sha1-XuWOqlounIDiFAe+3yOuWsCRs/w="
+		},
+		"is-ci": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
+			"integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+			"dev": true,
+			"requires": {
+				"ci-info": "1.1.2"
+			}
+		},
+		"is-dotfile": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+		},
+		"is-equal-shallow": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"requires": {
+				"is-primitive": "2.0.0"
+			}
+		},
+		"is-error": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/is-error/-/is-error-2.2.1.tgz",
+			"integrity": "sha1-aEqW2EB2V3yY9M20DG0mpRI78Zw=",
+			"dev": true
+		},
+		"is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+		},
+		"is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+		},
+		"is-finite": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+			"requires": {
+				"number-is-nan": "1.0.1"
+			}
+		},
+		"is-fullwidth-code-point": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+			"dev": true
+		},
+		"is-generator-fn": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
+			"integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=",
+			"dev": true
+		},
+		"is-get-set-prop": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-get-set-prop/-/is-get-set-prop-1.0.0.tgz",
+			"integrity": "sha1-JzGHfk14pqae3M5rudaLB3nnYxI=",
+			"dev": true,
+			"requires": {
+				"get-set-props": "0.1.0",
+				"lowercase-keys": "1.0.0"
+			}
+		},
+		"is-glob": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+			"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+			"requires": {
+				"is-extglob": "2.1.1"
+			}
+		},
+		"is-gzip": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
+			"integrity": "sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM="
+		},
+		"is-installed-globally": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+			"integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+			"dev": true,
+			"requires": {
+				"global-dirs": "0.1.1",
+				"is-path-inside": "1.0.1"
+			}
+		},
+		"is-js-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-js-type/-/is-js-type-2.0.0.tgz",
+			"integrity": "sha1-c2FwBtZZtOtHKbunR9KHgt8PfiI=",
+			"dev": true,
+			"requires": {
+				"js-types": "1.0.0"
+			}
+		},
+		"is-my-json-valid": {
+			"version": "2.16.1",
+			"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
+			"integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
+			"dev": true,
+			"requires": {
+				"generate-function": "2.0.0",
+				"generate-object-property": "1.2.0",
+				"jsonpointer": "4.0.1",
+				"xtend": "4.0.1"
+			}
+		},
+		"is-natural-number": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
+			"integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
+		},
+		"is-npm": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+			"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+			"dev": true
+		},
+		"is-number": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"requires": {
+				"kind-of": "3.2.2"
+			}
+		},
+		"is-obj": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+		},
+		"is-obj-prop": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-obj-prop/-/is-obj-prop-1.0.0.tgz",
+			"integrity": "sha1-s03nnEULjXxzqyzfZ9yHWtuF+A4=",
+			"dev": true,
+			"requires": {
+				"lowercase-keys": "1.0.0",
+				"obj-props": "1.1.0"
+			}
+		},
+		"is-object": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
+		},
+		"is-observable": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.0.0.tgz",
+			"integrity": "sha512-DVW97O/RiM3rTIuicUIcbJVqaQRDTwiXLYEWcCYLL5o8DOKCxpoPGroPXH3bVGUTJ2rvaFYnSXwwkakFpyTBzA==",
+			"dev": true,
+			"requires": {
+				"symbol-observable": "1.1.0"
+			}
+		},
+		"is-path-cwd": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+			"dev": true
+		},
+		"is-path-in-cwd": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+			"dev": true,
+			"requires": {
+				"is-path-inside": "1.0.1"
+			}
+		},
+		"is-path-inside": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+			"dev": true,
+			"requires": {
+				"path-is-inside": "1.0.2"
+			}
+		},
+		"is-plain-obj": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+		},
+		"is-posix-bracket": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+		},
+		"is-primitive": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+		},
+		"is-promise": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+			"dev": true
+		},
+		"is-property": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+			"integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+			"dev": true
+		},
+		"is-proto-prop": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-proto-prop/-/is-proto-prop-1.0.0.tgz",
+			"integrity": "sha1-s5UflcCJkk+11PzaZUKrPoPisiA=",
+			"dev": true,
+			"requires": {
+				"lowercase-keys": "1.0.0",
+				"proto-props": "0.2.1"
+			}
+		},
+		"is-redirect": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+		},
+		"is-relative": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
+			"integrity": "sha1-kF/uiuhvRbPsYUvDwVyGnfCHboI="
+		},
+		"is-resolvable": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+			"integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
+			"dev": true,
+			"requires": {
+				"tryit": "1.0.3"
+			}
+		},
+		"is-retry-allowed": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+		},
+		"is-tar": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-tar/-/is-tar-1.0.0.tgz",
+			"integrity": "sha1-L2suF5LB9bs2UZrKqdZcDSb+hT0="
+		},
+		"is-url": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.2.tgz",
+			"integrity": "sha1-SYkFpZO/R8wtnn9zg3K792lsfyY="
+		},
+		"is-utf8": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+		},
+		"is-valid-glob": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+			"integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4="
+		},
+		"is-zip": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz",
+			"integrity": "sha1-R7Co/004p2QxzP2ZqOFaTIa6IyU="
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+		},
+		"isobject": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"requires": {
+				"isarray": "1.0.0"
+			}
+		},
+		"isurl": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+			"integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+			"requires": {
+				"has-to-string-tag-x": "1.4.1",
+				"is-object": "1.0.1"
+			}
+		},
+		"js-string-escape": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
+			"integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=",
+			"dev": true
+		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+			"dev": true
+		},
+		"js-types": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/js-types/-/js-types-1.0.0.tgz",
+			"integrity": "sha1-0kLmSU7Vcq08koCfyL7X92h8vwM=",
+			"dev": true
+		},
+		"js-yaml": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+			"integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+			"dev": true,
+			"requires": {
+				"argparse": "1.0.9",
+				"esprima": "4.0.0"
+			}
+		},
+		"jsesc": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+			"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+			"dev": true
+		},
+		"json-stable-stringify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+			"requires": {
+				"jsonify": "0.0.0"
+			}
+		},
+		"json5": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+			"dev": true
+		},
+		"jsonify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+		},
+		"jsonpointer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+			"dev": true
+		},
+		"kind-of": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"requires": {
+				"is-buffer": "1.1.6"
+			}
+		},
+		"last-line-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/last-line-stream/-/last-line-stream-1.0.0.tgz",
+			"integrity": "sha1-0bZNafhv8kry0EiDos7uFFIKVgA=",
+			"dev": true,
+			"requires": {
+				"through2": "2.0.3"
+			},
+			"dependencies": {
+				"through2": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+					"dev": true,
+					"requires": {
+						"readable-stream": "2.3.3",
+						"xtend": "4.0.1"
+					}
+				}
+			}
+		},
+		"latest-version": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+			"integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+			"dev": true,
+			"requires": {
+				"package-json": "4.0.1"
+			}
+		},
+		"lazy-req": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz",
+			"integrity": "sha1-va6+rTD42CQDnODOFJ1Nqge6H6w="
+		},
+		"lazystream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+			"integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+			"requires": {
+				"readable-stream": "2.3.3"
+			}
+		},
+		"levn": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2"
+			}
+		},
+		"load-json-file": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"parse-json": "2.2.0",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"strip-bom": "2.0.0"
+			}
+		},
+		"locate-path": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"dev": true,
+			"requires": {
+				"p-locate": "2.0.0",
+				"path-exists": "3.0.0"
+			},
+			"dependencies": {
+				"path-exists": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+					"dev": true
+				}
+			}
+		},
+		"lodash": {
+			"version": "4.17.4",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+			"dev": true
+		},
+		"lodash._basecopy": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+			"integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
+		},
+		"lodash._basetostring": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+			"integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
+		},
+		"lodash._basevalues": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+			"integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
+		},
+		"lodash._getnative": {
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+		},
+		"lodash._isiterateecall": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+			"integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
+		},
+		"lodash._reescape": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+			"integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo="
+		},
+		"lodash._reevaluate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+			"integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0="
+		},
+		"lodash._reinterpolate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+		},
+		"lodash._root": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+			"integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
+		},
+		"lodash.camelcase": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+			"dev": true
+		},
+		"lodash.clonedeep": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+			"dev": true
+		},
+		"lodash.clonedeepwith": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.clonedeepwith/-/lodash.clonedeepwith-4.5.0.tgz",
+			"integrity": "sha1-buMFc6A6GmDWcKYu8zwQzxr9vdQ=",
+			"dev": true
+		},
+		"lodash.cond": {
+			"version": "4.5.2",
+			"resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
+			"integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
+			"dev": true
+		},
+		"lodash.debounce": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+			"dev": true
+		},
+		"lodash.difference": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+			"integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
+			"dev": true
+		},
+		"lodash.escape": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+			"integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+			"requires": {
+				"lodash._root": "3.0.1"
+			}
+		},
+		"lodash.flatten": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+			"dev": true
+		},
+		"lodash.flattendeep": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+			"dev": true
+		},
+		"lodash.isarguments": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+		},
+		"lodash.isarray": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+		},
+		"lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+		},
+		"lodash.kebabcase": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+			"integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
+			"dev": true
+		},
+		"lodash.keys": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+			"requires": {
+				"lodash._getnative": "3.9.1",
+				"lodash.isarguments": "3.1.0",
+				"lodash.isarray": "3.0.4"
+			}
+		},
+		"lodash.merge": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
+			"integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU=",
+			"dev": true
+		},
+		"lodash.restparam": {
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+			"integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
+		},
+		"lodash.snakecase": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+			"integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40=",
+			"dev": true
+		},
+		"lodash.template": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+			"integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+			"requires": {
+				"lodash._basecopy": "3.0.1",
+				"lodash._basetostring": "3.0.1",
+				"lodash._basevalues": "3.0.0",
+				"lodash._isiterateecall": "3.0.9",
+				"lodash._reinterpolate": "3.0.0",
+				"lodash.escape": "3.2.0",
+				"lodash.keys": "3.1.2",
+				"lodash.restparam": "3.6.1",
+				"lodash.templatesettings": "3.1.1"
+			}
+		},
+		"lodash.templatesettings": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+			"integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+			"requires": {
+				"lodash._reinterpolate": "3.0.0",
+				"lodash.escape": "3.2.0"
+			}
+		},
+		"lodash.upperfirst": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
+			"integrity": "sha1-E2Xt9DFIBIHvDRxolXpe2Z1J984=",
+			"dev": true
+		},
+		"log-symbols": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.1.0.tgz",
+			"integrity": "sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==",
+			"dev": true,
+			"requires": {
+				"chalk": "2.3.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "4.5.0"
+					}
+				},
+				"supports-color": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+					"dev": true,
+					"requires": {
+						"has-flag": "2.0.0"
+					}
+				}
+			}
+		},
+		"logalot": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/logalot/-/logalot-2.1.0.tgz",
+			"integrity": "sha1-X46MkNME7fElMJUaVVSruMXj9VI=",
+			"requires": {
+				"figures": "1.7.0",
+				"squeak": "1.3.0"
+			}
+		},
+		"longest": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+		},
+		"loose-envify": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+			"dev": true,
+			"requires": {
+				"js-tokens": "3.0.2"
+			}
+		},
+		"loud-rejection": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+			"requires": {
+				"currently-unhandled": "0.4.1",
+				"signal-exit": "3.0.2"
+			}
+		},
+		"lowercase-keys": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+			"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+		},
+		"lpad-align": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/lpad-align/-/lpad-align-1.1.2.tgz",
+			"integrity": "sha1-IfYArBwwlcPG5JfuZyce4ISB/p4=",
+			"requires": {
+				"get-stdin": "4.0.1",
+				"indent-string": "2.1.0",
+				"longest": "1.0.1",
+				"meow": "3.7.0"
+			}
+		},
+		"lru-cache": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+			"requires": {
+				"pseudomap": "1.0.2",
+				"yallist": "2.1.2"
+			}
+		},
+		"make-dir": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
+			"integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
+			"requires": {
+				"pify": "3.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
+			}
+		},
+		"map-obj": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+		},
+		"matcher": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/matcher/-/matcher-1.0.0.tgz",
+			"integrity": "sha1-qvDEgW62m5IJRnQXViXzRmsOPhk=",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "1.0.5"
+			}
+		},
+		"md5-hex": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
+			"integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
+			"dev": true,
+			"requires": {
+				"md5-o-matic": "0.1.1"
+			}
+		},
+		"md5-o-matic": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
+			"integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
+			"dev": true
+		},
+		"meow": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+			"requires": {
+				"camelcase-keys": "2.1.0",
+				"decamelize": "1.2.0",
+				"loud-rejection": "1.6.0",
+				"map-obj": "1.0.1",
+				"minimist": "1.2.0",
+				"normalize-package-data": "2.4.0",
+				"object-assign": "4.1.1",
+				"read-pkg-up": "1.0.1",
+				"redent": "1.0.0",
+				"trim-newlines": "1.0.0"
+			}
+		},
+		"merge-stream": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+			"requires": {
+				"readable-stream": "2.3.3"
+			}
+		},
+		"micromatch": {
+			"version": "2.3.11",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"requires": {
+				"arr-diff": "2.0.0",
+				"array-unique": "0.2.1",
+				"braces": "1.8.5",
+				"expand-brackets": "0.1.5",
+				"extglob": "0.3.2",
+				"filename-regex": "2.0.1",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1",
+				"kind-of": "3.2.2",
+				"normalize-path": "2.1.1",
+				"object.omit": "2.0.1",
+				"parse-glob": "3.0.4",
+				"regex-cache": "0.4.4"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				}
+			}
+		},
+		"mime-db": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.32.0.tgz",
+			"integrity": "sha512-+ZWo/xZN40Tt6S+HyakUxnSOgff+JEdaneLWIm0Z6LmpCn5DMcZntLyUY5c/rTDog28LhXLKOUZKoTxTCAdBVw=="
+		},
+		"mimic-fn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+			"integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+			"dev": true
+		},
+		"mimic-response": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
+			"integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4="
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"requires": {
+				"brace-expansion": "1.1.8"
+			}
+		},
+		"minimist": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+		},
+		"mkdirp": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"requires": {
+				"minimist": "0.0.8"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+				}
+			}
+		},
+		"ms": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+			"dev": true
+		},
+		"multimatch": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+			"dev": true,
+			"requires": {
+				"array-differ": "1.0.0",
+				"array-union": "1.0.2",
+				"arrify": "1.0.1",
+				"minimatch": "3.0.4"
+			}
+		},
+		"multipipe": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+			"integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+			"requires": {
+				"duplexer2": "0.0.2"
+			},
+			"dependencies": {
+				"duplexer2": {
+					"version": "0.0.2",
+					"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+					"integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+					"requires": {
+						"readable-stream": "1.1.14"
+					}
+				},
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+				},
+				"readable-stream": {
+					"version": "1.1.14",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "0.0.1",
+						"string_decoder": "0.10.31"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				}
+			}
+		},
+		"mute-stream": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+			"integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+			"dev": true
+		},
+		"natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
+		},
+		"node-status-codes": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
+			"integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8="
+		},
+		"normalize-package-data": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"requires": {
+				"hosted-git-info": "2.5.0",
+				"is-builtin-module": "1.0.0",
+				"semver": "5.4.1",
+				"validate-npm-package-license": "3.0.1"
+			}
+		},
+		"normalize-path": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"requires": {
+				"remove-trailing-separator": "1.1.0"
+			}
+		},
+		"npm-conf": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
+			"integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
+			"requires": {
+				"config-chain": "1.1.11",
+				"pify": "3.0.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
+			}
+		},
+		"npm-run-path": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+			"requires": {
+				"path-key": "2.0.1"
+			}
+		},
+		"number-is-nan": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+		},
+		"obj-props": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/obj-props/-/obj-props-1.1.0.tgz",
+			"integrity": "sha1-YmMT+qRCvv1KROmgLDy2vek3tRE=",
+			"dev": true
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
+		"object.omit": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"requires": {
+				"for-own": "0.1.5",
+				"is-extendable": "0.1.1"
+			}
+		},
+		"observable-to-promise": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/observable-to-promise/-/observable-to-promise-0.5.0.tgz",
+			"integrity": "sha1-yCjw8NxH6fhq+KSXfF1VB2znqR8=",
+			"dev": true,
+			"requires": {
+				"is-observable": "0.2.0",
+				"symbol-observable": "1.1.0"
+			},
+			"dependencies": {
+				"is-observable": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
+					"integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
+					"dev": true,
+					"requires": {
+						"symbol-observable": "0.2.4"
+					},
+					"dependencies": {
+						"symbol-observable": {
+							"version": "0.2.4",
+							"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
+							"integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A=",
+							"dev": true
+						}
+					}
+				}
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"requires": {
+				"wrappy": "1.0.2"
+			}
+		},
+		"onetime": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+			"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+		},
+		"option-chain": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/option-chain/-/option-chain-1.0.0.tgz",
+			"integrity": "sha1-k41zvU4Xg/lI00AjZEraI2aeMPI=",
+			"dev": true
+		},
+		"optionator": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"dev": true,
+			"requires": {
+				"deep-is": "0.1.3",
+				"fast-levenshtein": "2.0.6",
+				"levn": "0.3.0",
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2",
+				"wordwrap": "1.0.0"
+			}
+		},
+		"ordered-read-streams": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
+			"integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
+			"requires": {
+				"is-stream": "1.1.0",
+				"readable-stream": "2.3.3"
+			}
+		},
+		"os-filter-obj": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/os-filter-obj/-/os-filter-obj-1.0.3.tgz",
+			"integrity": "sha1-WRUzDZDs7VV9LZOKMcbdIU2cY60="
+		},
+		"os-homedir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
+		},
+		"os-tmpdir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
+		},
+		"p-cancelable": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+			"integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
+		},
+		"p-event": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/p-event/-/p-event-1.3.0.tgz",
+			"integrity": "sha1-jmtPT2XHK8W2/ii3XtqHT5akoIU=",
+			"requires": {
+				"p-timeout": "1.2.1"
+			}
+		},
+		"p-finally": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+		},
+		"p-limit": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+			"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
+			"dev": true
+		},
+		"p-locate": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+			"dev": true,
+			"requires": {
+				"p-limit": "1.1.0"
+			}
+		},
+		"p-map-series": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-map-series/-/p-map-series-1.0.0.tgz",
+			"integrity": "sha1-v5j+V1cFZYqeE1G++4WuTB8Hvco=",
+			"requires": {
+				"p-reduce": "1.0.0"
+			}
+		},
+		"p-reduce": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
+			"integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo="
+		},
+		"p-timeout": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
+			"integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
+			"requires": {
+				"p-finally": "1.0.0"
+			}
+		},
+		"package-hash": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-2.0.0.tgz",
+			"integrity": "sha1-eK4ybIngWk2BO2hgGXevBcANKg0=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"lodash.flattendeep": "4.4.0",
+				"md5-hex": "2.0.0",
+				"release-zalgo": "1.0.0"
+			}
+		},
+		"package-json": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+			"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+			"dev": true,
+			"requires": {
+				"got": "6.7.1",
+				"registry-auth-token": "3.3.1",
+				"registry-url": "3.1.0",
+				"semver": "5.4.1"
+			},
+			"dependencies": {
+				"get-stream": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+					"dev": true
+				},
+				"got": {
+					"version": "6.7.1",
+					"resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+					"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+					"dev": true,
+					"requires": {
+						"create-error-class": "3.0.2",
+						"duplexer3": "0.1.4",
+						"get-stream": "3.0.0",
+						"is-redirect": "1.0.0",
+						"is-retry-allowed": "1.1.0",
+						"is-stream": "1.1.0",
+						"lowercase-keys": "1.0.0",
+						"safe-buffer": "5.1.1",
+						"timed-out": "4.0.1",
+						"unzip-response": "2.0.1",
+						"url-parse-lax": "1.0.0"
+					}
+				},
+				"unzip-response": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+					"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
+					"dev": true
+				}
+			}
+		},
+		"parse-glob": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"requires": {
+				"glob-base": "0.3.0",
+				"is-dotfile": "1.0.3",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1"
+			},
+			"dependencies": {
+				"is-extglob": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+				},
+				"is-glob": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+					"requires": {
+						"is-extglob": "1.0.0"
+					}
+				}
+			}
+		},
+		"parse-json": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"requires": {
+				"error-ex": "1.3.1"
+			}
+		},
+		"parse-ms": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
+			"integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=",
+			"dev": true
+		},
+		"path-dirname": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
+		},
+		"path-exists": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+			"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+			"requires": {
+				"pinkie-promise": "2.0.1"
+			}
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"path-is-inside": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+			"dev": true
+		},
+		"path-key": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+		},
+		"path-parse": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+			"dev": true
+		},
+		"path-type": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1"
+			}
+		},
+		"pend": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+			"integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+		},
+		"pify": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+		},
+		"pinkie": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+		},
+		"pinkie-promise": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"requires": {
+				"pinkie": "2.0.4"
+			}
+		},
+		"pkg-conf": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.0.0.tgz",
+			"integrity": "sha1-BxyHZQQDvM+5xif1h1G/5HwGcnk=",
+			"dev": true,
+			"requires": {
+				"find-up": "2.1.0",
+				"load-json-file": "2.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
+					"requires": {
+						"locate-path": "2.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"strip-bom": "3.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+					"dev": true
+				}
+			}
+		},
+		"pkg-dir": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+			"dev": true,
+			"requires": {
+				"find-up": "2.1.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
+					"requires": {
+						"locate-path": "2.0.0"
+					}
+				}
+			}
+		},
+		"pkg-up": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+			"integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+			"dev": true,
+			"requires": {
+				"find-up": "2.1.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
+					"requires": {
+						"locate-path": "2.0.0"
+					}
+				}
+			}
+		},
+		"plur": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+			"integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
+			"dev": true,
+			"requires": {
+				"irregular-plurals": "1.4.0"
+			}
+		},
+		"pluralize": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+			"integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+			"dev": true
+		},
+		"prelude-ls": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
+		},
+		"prepend-http": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+		},
+		"preserve": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+		},
+		"pretty-ms": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.1.0.tgz",
+			"integrity": "sha1-6crJx2v27lL+lC3ZxsQhMVOxKIE=",
+			"dev": true,
+			"requires": {
+				"parse-ms": "1.0.1",
+				"plur": "2.1.2"
+			}
+		},
+		"private": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+			"dev": true
+		},
+		"process-nextick-args": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+		},
+		"progress": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+			"integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+			"dev": true
+		},
+		"proto-list": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
+		},
+		"proto-props": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/proto-props/-/proto-props-0.2.1.tgz",
+			"integrity": "sha1-XgHcJnWg3pq/p255nfozTW9IP0s=",
+			"dev": true
+		},
+		"pseudomap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+		},
+		"randomatic": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+			"requires": {
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"requires": {
+						"is-buffer": "1.1.6"
+					}
+				}
+			}
+		},
+		"rc": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
+			"integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
+			"requires": {
+				"deep-extend": "0.4.2",
+				"ini": "1.3.5",
+				"minimist": "1.2.0",
+				"strip-json-comments": "2.0.1"
+			}
+		},
+		"read-all-stream": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
+			"integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
+			"requires": {
+				"pinkie-promise": "2.0.1",
+				"readable-stream": "2.3.3"
+			}
+		},
+		"read-pkg": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+			"requires": {
+				"load-json-file": "1.1.0",
+				"normalize-package-data": "2.4.0",
+				"path-type": "1.1.0"
+			}
+		},
+		"read-pkg-up": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+			"requires": {
+				"find-up": "1.1.2",
+				"read-pkg": "1.1.0"
+			}
+		},
+		"readable-stream": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+			"requires": {
+				"core-util-is": "1.0.2",
+				"inherits": "2.0.3",
+				"isarray": "1.0.0",
+				"process-nextick-args": "1.0.7",
+				"safe-buffer": "5.1.1",
+				"string_decoder": "1.0.3",
+				"util-deprecate": "1.0.2"
+			}
+		},
+		"readdirp": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"minimatch": "3.0.4",
+				"readable-stream": "2.3.3",
+				"set-immediate-shim": "1.0.1"
+			}
+		},
+		"readline2": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+			"integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+			"dev": true,
+			"requires": {
+				"code-point-at": "1.1.0",
+				"is-fullwidth-code-point": "1.0.0",
+				"mute-stream": "0.0.5"
+			},
+			"dependencies": {
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				}
+			}
+		},
+		"rechoir": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+			"dev": true,
+			"requires": {
+				"resolve": "1.5.0"
+			}
+		},
+		"redent": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+			"requires": {
+				"indent-string": "2.1.0",
+				"strip-indent": "1.0.1"
+			}
+		},
+		"regenerate": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
+			"integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+			"dev": true
+		},
+		"regenerator-runtime": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+			"integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+			"dev": true
+		},
+		"regex-cache": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+			"requires": {
+				"is-equal-shallow": "0.1.3"
+			}
+		},
+		"regexpu-core": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+			"dev": true,
+			"requires": {
+				"regenerate": "1.3.3",
+				"regjsgen": "0.2.0",
+				"regjsparser": "0.1.5"
+			}
+		},
+		"registry-auth-token": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
+			"integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
+			"dev": true,
+			"requires": {
+				"rc": "1.2.2",
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"registry-url": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+			"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+			"dev": true,
+			"requires": {
+				"rc": "1.2.2"
+			}
+		},
+		"regjsgen": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+			"dev": true
+		},
+		"regjsparser": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+			"dev": true,
+			"requires": {
+				"jsesc": "0.5.0"
+			}
+		},
+		"release-zalgo": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+			"integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+			"dev": true,
+			"requires": {
+				"es6-error": "4.0.2"
+			}
+		},
+		"remove-trailing-separator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+		},
+		"repeat-element": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+		},
+		"repeat-string": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+		},
+		"repeating": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+			"requires": {
+				"is-finite": "1.0.2"
+			}
+		},
+		"replace-ext": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+			"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+		},
+		"require-precompiled": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/require-precompiled/-/require-precompiled-0.1.0.tgz",
+			"integrity": "sha1-WhtS63Dr7UPrmC6XTIWrWVceVvo=",
+			"dev": true
+		},
+		"require-uncached": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+			"dev": true,
+			"requires": {
+				"caller-path": "0.1.0",
+				"resolve-from": "1.0.1"
+			},
+			"dependencies": {
+				"resolve-from": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+					"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+					"dev": true
+				}
+			}
+		},
+		"resolve": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+			"integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+			"dev": true,
+			"requires": {
+				"path-parse": "1.0.5"
+			}
+		},
+		"resolve-cwd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+			"dev": true,
+			"requires": {
+				"resolve-from": "3.0.0"
+			}
+		},
+		"resolve-from": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+			"dev": true
+		},
+		"restore-cursor": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"dev": true,
+			"requires": {
+				"onetime": "2.0.1",
+				"signal-exit": "3.0.2"
+			},
+			"dependencies": {
+				"onetime": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+					"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+					"dev": true,
+					"requires": {
+						"mimic-fn": "1.1.0"
+					}
+				}
+			}
+		},
+		"rimraf": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"dev": true,
+			"requires": {
+				"glob": "7.1.2"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				}
+			}
+		},
+		"run-async": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+			"integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+			"dev": true,
+			"requires": {
+				"once": "1.4.0"
+			}
+		},
+		"rx-lite": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+			"integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+			"dev": true
+		},
+		"safe-buffer": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+		},
+		"seek-bzip": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
+			"integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
+			"requires": {
+				"commander": "2.8.1"
+			}
+		},
+		"semver": {
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+			"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+		},
+		"semver-diff": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+			"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+			"dev": true,
+			"requires": {
+				"semver": "5.4.1"
+			}
+		},
+		"semver-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz",
+			"integrity": "sha1-kqSWkGX5xwxpR1PVUkj8aPj2Usk="
+		},
+		"semver-truncate": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.1.2.tgz",
+			"integrity": "sha1-V/Qd5pcHpicJp+AQS6IRcQnqR+g=",
+			"requires": {
+				"semver": "5.4.1"
+			}
+		},
+		"set-immediate-shim": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+		},
+		"shebang-command": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"requires": {
+				"shebang-regex": "1.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+		},
+		"shelljs": {
+			"version": "0.7.8",
+			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+			"integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+			"dev": true,
+			"requires": {
+				"glob": "7.1.2",
+				"interpret": "1.1.0",
+				"rechoir": "0.6.2"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				}
+			}
+		},
+		"signal-exit": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+		},
+		"slash": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+			"dev": true
+		},
+		"slice-ansi": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+			"dev": true,
+			"requires": {
+				"is-fullwidth-code-point": "2.0.0"
+			}
+		},
+		"slide": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+			"dev": true
+		},
+		"sort-keys": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+			"integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+			"requires": {
+				"is-plain-obj": "1.1.0"
+			}
+		},
+		"sort-keys-length": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
+			"integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
+			"requires": {
+				"sort-keys": "1.1.2"
+			}
+		},
+		"source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true
+		},
+		"source-map-support": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz",
+			"integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
+			"dev": true,
+			"requires": {
+				"source-map": "0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
+		"sparkles": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+			"integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM="
+		},
+		"spdx-correct": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+			"requires": {
+				"spdx-license-ids": "1.2.2"
+			}
+		},
+		"spdx-expression-parse": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+			"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+		},
+		"spdx-license-ids": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
+		},
+		"squeak": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/squeak/-/squeak-1.3.0.tgz",
+			"integrity": "sha1-MwRQN7ZDiLVnZ0uEMiplIQc5FsM=",
+			"requires": {
+				"chalk": "1.1.3",
+				"console-stream": "0.1.1",
+				"lpad-align": "1.1.2"
+			}
+		},
+		"stack-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
+			"integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
+			"dev": true
+		},
+		"stat-mode": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
+			"integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI="
+		},
+		"stream-combiner2": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+			"integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
+			"requires": {
+				"duplexer2": "0.1.4",
+				"readable-stream": "2.3.3"
+			}
+		},
+		"stream-shift": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+		},
+		"string-width": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"dev": true,
+			"requires": {
+				"is-fullwidth-code-point": "2.0.0",
+				"strip-ansi": "4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				}
+			}
+		},
+		"string_decoder": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"strip-ansi": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"requires": {
+				"ansi-regex": "2.1.1"
+			}
+		},
+		"strip-bom": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+			"requires": {
+				"is-utf8": "0.2.1"
+			}
+		},
+		"strip-bom-buf": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
+			"integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
+			"dev": true,
+			"requires": {
+				"is-utf8": "0.2.1"
+			}
+		},
+		"strip-bom-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
+			"integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
+			"requires": {
+				"first-chunk-stream": "1.0.0",
+				"strip-bom": "2.0.0"
+			}
+		},
+		"strip-dirs": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
+			"integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
+			"requires": {
+				"is-natural-number": "4.0.1"
+			}
+		},
+		"strip-eof": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+		},
+		"strip-indent": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+			"requires": {
+				"get-stdin": "4.0.1"
+			}
+		},
+		"strip-json-comments": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+		},
+		"strip-outer": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.0.tgz",
+			"integrity": "sha1-qsC6YNLpDF1PJ1/Yhp/ZotMQ/7g=",
+			"requires": {
+				"escape-string-regexp": "1.0.5"
+			}
+		},
+		"sum-up": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.3.tgz",
+			"integrity": "sha1-HGYfZnBX9jvLeHWqFDi8FiUlFW4=",
+			"requires": {
+				"chalk": "1.1.3"
+			}
+		},
+		"supports-color": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+		},
+		"symbol-observable": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.1.0.tgz",
+			"integrity": "sha512-dQoid9tqQ+uotGhuTKEY11X4xhyYePVnqGSoSm3OGKh2E8LZ6RPULp1uXTctk33IeERlrRJYoVSBglsL05F5Uw==",
+			"dev": true
+		},
+		"table": {
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+			"integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+			"dev": true,
+			"requires": {
+				"ajv": "4.11.8",
+				"ajv-keywords": "1.5.1",
+				"chalk": "1.1.3",
+				"lodash": "4.17.4",
+				"slice-ansi": "0.0.4",
+				"string-width": "2.1.1"
+			},
+			"dependencies": {
+				"slice-ansi": {
+					"version": "0.0.4",
+					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+					"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+					"dev": true
+				}
+			}
+		},
+		"tar-stream": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
+			"integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
+			"requires": {
+				"bl": "1.2.1",
+				"end-of-stream": "1.4.0",
+				"readable-stream": "2.3.3",
+				"xtend": "4.0.1"
+			}
+		},
+		"temp-dir": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
+			"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0="
+		},
+		"tempfile": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/tempfile/-/tempfile-2.0.0.tgz",
+			"integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
+			"requires": {
+				"temp-dir": "1.0.0",
+				"uuid": "3.1.0"
+			}
+		},
+		"tempy": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/tempy/-/tempy-0.2.1.tgz",
+			"integrity": "sha512-LB83o9bfZGrntdqPuRdanIVCPReam9SOZKW0fOy5I9X3A854GGWi0tjCqoXEk84XIEYBc/x9Hq3EFop/H5wJaw==",
+			"dev": true,
+			"requires": {
+				"temp-dir": "1.0.0",
+				"unique-string": "1.0.0"
+			}
+		},
+		"term-size": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+			"integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+			"dev": true,
+			"requires": {
+				"execa": "0.7.0"
+			},
+			"dependencies": {
+				"execa": {
+					"version": "0.7.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "5.1.0",
+						"get-stream": "3.0.0",
+						"is-stream": "1.1.0",
+						"npm-run-path": "2.0.2",
+						"p-finally": "1.0.0",
+						"signal-exit": "3.0.2",
+						"strip-eof": "1.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+					"dev": true
+				}
+			}
+		},
+		"text-table": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"dev": true
+		},
+		"the-argv": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/the-argv/-/the-argv-1.0.0.tgz",
+			"integrity": "sha1-AIRwUAVzDdhNt1UlPJMa45jblSI=",
+			"dev": true
+		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+		},
+		"through2": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+			"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+			"requires": {
+				"readable-stream": "1.0.34",
+				"xtend": "4.0.1"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+				},
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "0.0.1",
+						"string_decoder": "0.10.31"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				}
+			}
+		},
+		"through2-filter": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
+			"integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
+			"requires": {
+				"through2": "2.0.3",
+				"xtend": "4.0.1"
+			},
+			"dependencies": {
+				"through2": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+					"requires": {
+						"readable-stream": "2.3.3",
+						"xtend": "4.0.1"
+					}
+				}
+			}
+		},
+		"time-require": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/time-require/-/time-require-0.1.2.tgz",
+			"integrity": "sha1-+eEss3D8JgXhFARYK6VO9corLZg=",
+			"dev": true,
+			"requires": {
+				"chalk": "0.4.0",
+				"date-time": "0.1.1",
+				"pretty-ms": "0.2.2",
+				"text-table": "0.2.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+					"integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+					"integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "1.0.0",
+						"has-color": "0.1.7",
+						"strip-ansi": "0.1.1"
+					}
+				},
+				"date-time": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/date-time/-/date-time-0.1.1.tgz",
+					"integrity": "sha1-7S9tk9l5DOL9ZtW1/z7dW7y/Owc=",
+					"dev": true
+				},
+				"parse-ms": {
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-0.1.2.tgz",
+					"integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4=",
+					"dev": true
+				},
+				"pretty-ms": {
+					"version": "0.2.2",
+					"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-0.2.2.tgz",
+					"integrity": "sha1-2oeaaC/zOjcBEEbxPWJ/Z8c7hPY=",
+					"dev": true,
+					"requires": {
+						"parse-ms": "0.1.2"
+					}
+				},
+				"strip-ansi": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+					"integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
+					"dev": true
+				}
+			}
+		},
+		"time-stamp": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+			"integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
+		},
+		"time-zone": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
+			"integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=",
+			"dev": true
+		},
+		"timed-out": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+		},
+		"to-absolute-glob": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
+			"integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
+			"requires": {
+				"extend-shallow": "2.0.1"
+			}
+		},
+		"to-fast-properties": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+			"dev": true
+		},
+		"trim-newlines": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+			"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+		},
+		"trim-off-newlines": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
+			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
+			"dev": true
+		},
+		"trim-repeated": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+			"integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
+			"requires": {
+				"escape-string-regexp": "1.0.5"
+			}
+		},
+		"trim-right": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+			"dev": true
+		},
+		"tryit": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
+			"integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
+			"dev": true
+		},
+		"tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"type-check": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "1.1.2"
+			}
+		},
+		"typedarray": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+		},
+		"uid2": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+			"integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=",
+			"dev": true
+		},
+		"unbzip2-stream": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.2.5.tgz",
+			"integrity": "sha512-izD3jxT8xkzwtXRUZjtmRwKnZoeECrfZ8ra/ketwOcusbZEp4mjULMnJOCfTDZBgGQAAY1AJ/IgxcwkavcX9Og==",
+			"requires": {
+				"buffer": "3.6.0",
+				"through": "2.3.8"
+			}
+		},
+		"unique-stream": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
+			"integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
+			"requires": {
+				"json-stable-stringify": "1.0.1",
+				"through2-filter": "2.0.0"
+			}
+		},
+		"unique-string": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+			"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+			"dev": true,
+			"requires": {
+				"crypto-random-string": "1.0.0"
+			}
+		},
+		"unique-temp-dir": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unique-temp-dir/-/unique-temp-dir-1.0.0.tgz",
+			"integrity": "sha1-bc6VsmgcoAPuv7MEpBX5y6vMU4U=",
+			"dev": true,
+			"requires": {
+				"mkdirp": "0.5.1",
+				"os-tmpdir": "1.0.2",
+				"uid2": "0.0.3"
+			}
+		},
+		"unzip-response": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
+			"integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
+		},
+		"update-notifier": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
+			"integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
+			"dev": true,
+			"requires": {
+				"boxen": "1.3.0",
+				"chalk": "2.3.0",
+				"configstore": "3.1.1",
+				"import-lazy": "2.1.0",
+				"is-installed-globally": "0.1.0",
+				"is-npm": "1.0.0",
+				"latest-version": "3.1.0",
+				"semver-diff": "2.1.0",
+				"xdg-basedir": "3.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.1"
+					}
+				},
+				"chalk": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "4.5.0"
+					}
+				},
+				"supports-color": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+					"dev": true,
+					"requires": {
+						"has-flag": "2.0.0"
+					}
+				}
+			}
+		},
+		"url-parse-lax": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+			"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+			"requires": {
+				"prepend-http": "1.0.4"
+			}
+		},
+		"url-to-options": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+			"integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
+		},
+		"user-home": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+			"integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+			"dev": true,
+			"requires": {
+				"os-homedir": "1.0.2"
+			}
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+		},
+		"uuid": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+			"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+		},
+		"vali-date": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+			"integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY="
+		},
+		"validate-npm-package-license": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+			"requires": {
+				"spdx-correct": "1.0.2",
+				"spdx-expression-parse": "1.0.4"
+			}
+		},
+		"vinyl": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+			"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+			"requires": {
+				"clone": "1.0.3",
+				"clone-stats": "0.0.1",
+				"replace-ext": "0.0.1"
+			}
+		},
+		"vinyl-assign": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.2.1.tgz",
+			"integrity": "sha1-TRmIkbVRWRHXcajNnFSApGoHSkU=",
+			"requires": {
+				"object-assign": "4.1.1",
+				"readable-stream": "2.3.3"
+			}
+		},
+		"vinyl-fs": {
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+			"integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
+			"requires": {
+				"duplexify": "3.5.1",
+				"glob-stream": "5.3.5",
+				"graceful-fs": "4.1.11",
+				"gulp-sourcemaps": "1.6.0",
+				"is-valid-glob": "0.3.0",
+				"lazystream": "1.0.0",
+				"lodash.isequal": "4.5.0",
+				"merge-stream": "1.0.1",
+				"mkdirp": "0.5.1",
+				"object-assign": "4.1.1",
+				"readable-stream": "2.3.3",
+				"strip-bom": "2.0.0",
+				"strip-bom-stream": "1.0.0",
+				"through2": "2.0.3",
+				"through2-filter": "2.0.0",
+				"vali-date": "1.0.0",
+				"vinyl": "1.2.0"
+			},
+			"dependencies": {
+				"through2": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+					"requires": {
+						"readable-stream": "2.3.3",
+						"xtend": "4.0.1"
+					}
+				}
+			}
+		},
+		"ware": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
+			"integrity": "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=",
+			"requires": {
+				"wrap-fn": "0.1.5"
+			}
+		},
+		"well-known-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-1.0.0.tgz",
+			"integrity": "sha1-c8eK6Bp3Jqj6WY4ogIAcixYiVRg=",
+			"dev": true
+		},
+		"which": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+			"requires": {
+				"isexe": "2.0.0"
+			}
+		},
+		"widest-line": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
+			"integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
+			"dev": true,
+			"requires": {
+				"string-width": "2.1.1"
+			}
+		},
+		"wordwrap": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+			"dev": true
+		},
+		"wrap-fn": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.5.tgz",
+			"integrity": "sha1-8htuQQFv9KfjFyDbxjoJAWvfmEU=",
+			"requires": {
+				"co": "3.1.0"
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"write": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+			"dev": true,
+			"requires": {
+				"mkdirp": "0.5.1"
+			}
+		},
+		"write-file-atomic": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"imurmurhash": "0.1.4",
+				"signal-exit": "3.0.2"
+			}
+		},
+		"write-json-file": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.3.0.tgz",
+			"integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
+			"dev": true,
+			"requires": {
+				"detect-indent": "5.0.0",
+				"graceful-fs": "4.1.11",
+				"make-dir": "1.1.0",
+				"pify": "3.0.0",
+				"sort-keys": "2.0.0",
+				"write-file-atomic": "2.3.0"
+			},
+			"dependencies": {
+				"detect-indent": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+					"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
+					"dev": true
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				},
+				"sort-keys": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+					"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+					"dev": true,
+					"requires": {
+						"is-plain-obj": "1.1.0"
+					}
+				}
+			}
+		},
+		"write-pkg": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-3.1.0.tgz",
+			"integrity": "sha1-AwqZlMyZk9JbTnWp8aGSNgcpHOk=",
+			"dev": true,
+			"requires": {
+				"sort-keys": "2.0.0",
+				"write-json-file": "2.3.0"
+			},
+			"dependencies": {
+				"sort-keys": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+					"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+					"dev": true,
+					"requires": {
+						"is-plain-obj": "1.1.0"
+					}
+				}
+			}
+		},
+		"xdg-basedir": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+			"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+			"dev": true
+		},
+		"xo": {
+			"version": "0.18.2",
+			"resolved": "https://registry.npmjs.org/xo/-/xo-0.18.2.tgz",
+			"integrity": "sha1-kqQusCpPsUnf6lUYAhkU9arIT/A=",
+			"dev": true,
+			"requires": {
+				"arrify": "1.0.1",
+				"debug": "2.6.9",
+				"deep-assign": "1.0.0",
+				"eslint": "3.19.0",
+				"eslint-config-xo": "0.18.2",
+				"eslint-formatter-pretty": "1.3.0",
+				"eslint-plugin-ava": "4.3.0",
+				"eslint-plugin-import": "2.8.0",
+				"eslint-plugin-no-use-extend-native": "0.3.12",
+				"eslint-plugin-promise": "3.6.0",
+				"eslint-plugin-unicorn": "2.1.2",
+				"get-stdin": "5.0.1",
+				"globby": "6.1.0",
+				"has-flag": "2.0.0",
+				"ignore": "3.3.7",
+				"lodash.isequal": "4.5.0",
+				"meow": "3.7.0",
+				"multimatch": "2.1.0",
+				"path-exists": "3.0.0",
+				"pkg-conf": "2.0.0",
+				"resolve-cwd": "1.0.0",
+				"resolve-from": "2.0.0",
+				"slash": "1.0.0",
+				"update-notifier": "2.3.0",
+				"xo-init": "0.5.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"get-stdin": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+					"integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				},
+				"path-exists": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+					"dev": true
+				},
+				"resolve-cwd": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-1.0.0.tgz",
+					"integrity": "sha1-Tq7qQe0EDRcCRX32SkKysH0kb58=",
+					"dev": true,
+					"requires": {
+						"resolve-from": "2.0.0"
+					}
+				},
+				"resolve-from": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+					"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+					"dev": true
+				}
+			}
+		},
+		"xo-init": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/xo-init/-/xo-init-0.5.0.tgz",
+			"integrity": "sha1-jijex5Z2zF4EL95f2PcQ4mRrDjY=",
+			"dev": true,
+			"requires": {
+				"arrify": "1.0.1",
+				"execa": "0.5.1",
+				"minimist": "1.2.0",
+				"path-exists": "3.0.0",
+				"read-pkg-up": "2.0.0",
+				"the-argv": "1.0.0",
+				"write-pkg": "2.1.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+					"integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+					"dev": true,
+					"requires": {
+						"lru-cache": "4.1.1",
+						"which": "1.3.0"
+					}
+				},
+				"execa": {
+					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz",
+					"integrity": "sha1-3j+4XLjW6RyFvLzrFkWBeFy1ezY=",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "4.0.2",
+						"get-stream": "2.3.1",
+						"is-stream": "1.1.0",
+						"npm-run-path": "2.0.2",
+						"p-finally": "1.0.0",
+						"signal-exit": "3.0.2",
+						"strip-eof": "1.0.0"
+					}
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
+					"requires": {
+						"locate-path": "2.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"strip-bom": "3.0.0"
+					}
+				},
+				"path-exists": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+					"dev": true
+				},
+				"path-type": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+					"dev": true,
+					"requires": {
+						"pify": "2.3.0"
+					}
+				},
+				"read-pkg": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "2.0.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "2.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+					"dev": true,
+					"requires": {
+						"find-up": "2.1.0",
+						"read-pkg": "2.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+					"dev": true
+				},
+				"write-pkg": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-2.1.0.tgz",
+					"integrity": "sha1-NTqkTDnEjCFED1wIzmq9RhQcnAg=",
+					"dev": true,
+					"requires": {
+						"sort-keys": "1.1.2",
+						"write-json-file": "2.3.0"
+					}
+				}
+			}
+		},
+		"xtend": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+		},
+		"yallist": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+		},
+		"yauzl": {
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
+			"integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
+			"requires": {
+				"buffer-crc32": "0.2.13",
+				"fd-slicer": "1.0.1"
+			}
+		}
+	}
+}


### PR DESCRIPTION
The [`package-lock.json` file](https://docs.npmjs.com/files/package-lock.json) was made to lock the packages dependencies and ensure that they are the same across different installations.

I propose to add it in this package :-)
That could also prevent some eventual installation fails.

PS : Is it possible to publish the current changes on the GitHub repo to npm ?