### PR TITLE
Fail the postinstall script if compiling fails

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -24,7 +24,7 @@ bin.run(['--version'], err => {
 				logalot.error(err.stack);
 
 				// Mark the install as failed so the user doesn't accidentally think it worked
-				// eslint-disable-next-line no-process-exit
+				// eslint-disable-next-line unicorn/no-process-exit
 				process.exit(1);
 			});
 	}

--- a/lib/install.js
+++ b/lib/install.js
@@ -23,7 +23,6 @@ bin.run(['--version'], err => {
 				err.message = `pngquant failed to build, make sure that ${libpng} is installed`;
 				logalot.error(err.stack);
 
-				// Mark the install as failed so the user doesn't accidentally think it worked
 				// eslint-disable-next-line unicorn/no-process-exit
 				process.exit(1);
 			});

--- a/lib/install.js
+++ b/lib/install.js
@@ -22,6 +22,10 @@ bin.run(['--version'], err => {
 			.catch(err => {
 				err.message = `pngquant failed to build, make sure that ${libpng} is installed`;
 				logalot.error(err.stack);
+
+				// Mark the install as failed so the user doesn't accidentally think it worked
+				// eslint-disable-next-line no-process-exit
+				process.exit(1);
 			});
 	}
 


### PR DESCRIPTION
If the pngquant binary does not work and the compile fails, npm should
fail the package installation, since it will not work. Previously it
would log an error, but return exit code 0 so npm would think the
package was installed correctly. This will make it easier for users to
figure out why pngquant isn't working.

---

 Fixes #72 