### PR TITLE
Remove process.exit(1); for npm install.

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -24,7 +24,7 @@ bin.run(['--version'], err => {
 				logalot.error(err.stack);
 
 				// eslint-disable-next-line unicorn/no-process-exit
-				process.exit(1);
+				//process.exit(1);
 			});
 	}
 


### PR DESCRIPTION
This line is causing many people to stop from being able to deploy. (see this issue https://github.com/imagemin/pngquant-bin/issues/78) Can this be changed to determine whether libpng-dev can be installed on the system and stop the process if it can be installed with a warning to the user to install libpng-dev, else just continue on installing npm packages? It seems that systems with a commad of apt-get have access to libpgn-dev. 

This line is literally stopping the deployment of apps on systems where libpng-dev cannot be installed.

I am on CentOS and there is no libpng-dev package for that system. 

Thank you!