### PR TITLE
default to https. http redirects to https.

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -11,7 +11,7 @@ bin.run(['--version'], err => {
 
 		const libpng = process.platform === 'darwin' ? 'libpng' : 'libpng-dev';
 
-		binBuild.url('http://pngquant.org/pngquant-2.10.1-src.tar.gz', [
+		binBuild.url('https://pngquant.org/pngquant-2.10.1-src.tar.gz', [
 			'rm ./INSTALL',
 			`./configure --prefix="${bin.dest()}"`,
 			`make install BINPREFIX="${bin.dest()}"`


### PR DESCRIPTION
the http to https redirect breaks some installers.

resolves #78 as the OP error is failing on the net call