### PR TITLE
http to https

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -11,7 +11,7 @@ bin.run(['--version'], err => {
 
 		const libpng = process.platform === 'darwin' ? 'libpng' : 'libpng-dev';
 
-		binBuild.url('http://pngquant.org/pngquant-2.10.1-src.tar.gz', [
+		binBuild.url('https://pngquant.org/pngquant-2.10.1-src.tar.gz', [
 			'rm ./INSTALL',
 			`./configure --prefix="${bin.dest()}"`,
 			`make install BINPREFIX="${bin.dest()}"`


### PR DESCRIPTION
Http will cause redirects to https each time, rather than using https directly