### PR TITLE
update bin-wrapper to fix npm audit warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 	],
 	"dependencies": {
 		"bin-build": "^3.0.0",
-		"bin-wrapper": "^3.0.0",
+		"bin-wrapper": "^4.0.0",
 		"execa": "^0.10.0",
 		"logalot": "^2.0.0"
 	},


### PR DESCRIPTION
- Addresses `npm audit` warning
- `npm test` continues to pass
- However, bin-wrapper changed their public api (https://github.com/kevva/bin-wrapper/commits/master)

Presumably this would cause problems for packages depending on pngquant-bin.

How might this PR be patched to be more safe?