### PR TITLE
Use raw.githubusercontent.com instead of raw.github.com for binaries

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@ const path = require('path');
 const BinWrapper = require('bin-wrapper');
 const pkg = require('../package.json');
 
-const url = `https://raw.github.com/imagemin/pngquant-bin/v${pkg.version}/vendor/`;
+const url = `https://raw.githubusercontent.com/imagemin/pngquant-bin/v${pkg.version}/vendor/`;
 
 module.exports = new BinWrapper()
 	.src(`${url}macos/pngquant`, 'darwin')


### PR DESCRIPTION
According to [Github](https://developer.github.com/changes/2014-04-25-user-content-security/) to avoid XSS all user-generated content must be accesed from alternative domain: `raw.githubusercontent.com`.

Current:
```sh
curl -I -XGET https://raw.github.com/imagemin/pngquant-bin/v5.0.1/vendor/macos/pngquant
HTTP/1.1 503 Backend unavailable, connection timeout
```

Updated:
```sh
curl -I -XGET https://raw.githubusercontent.com/imagemin/pngquant-bin/v5.0.1/vendor/macos/pngquant
HTTP/1.1 200 OK
```

______

**UPD**: as @cadejscroggins indicated [below](https://github.com/imagemin/pngquant-bin/pull/99#issuecomment-465356928) `raw.github.com` seems to be working now, but would be nice to be sure that issue will not appear again some day.