### PR TITLE
Change URL for raw Github content CDN

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@ const path = require('path');
 const BinWrapper = require('bin-wrapper');
 const pkg = require('../package.json');
 
-const url = `https://raw.github.com/imagemin/pngquant-bin/v${pkg.version}/vendor/`;
+const url = `https://raw.githubusercontent.com/imagemin/pngquant-bin/v${pkg.version}/vendor/`;
 
 module.exports = new BinWrapper()
 	.src(`${url}macos/pngquant`, 'darwin')


### PR DESCRIPTION
When installing pngquant-bin, I get this error.

```Exit code: 1
Command: node lib/install.js
Arguments:
Directory: /Users/pieterbeulque/baremetrics/baremetrics-marketing-v4/wp-content/themes/baremetrics_dev/node_modules/pngquant-bin
Output:
⚠ Response code 503 (Backend unavailable, connection timeout)
  ⚠ pngquant pre-build test failed
  ℹ compiling from source```

This PR fixes that.