### PR TITLE
Use the license of the combined software

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "pngquant-bin",
 	"version": "5.0.2",
 	"description": "`pngquant` wrapper that makes it seamlessly available as a local dependency",
-	"license": "MIT",
+	"license": "GPL-3.0+",
 	"repository": "imagemin/pngquant-bin",
 	"author": {
 		"name": "Kevin Mårtensson",


### PR DESCRIPTION
pngquant-bin includes and redistributes GPL-licensed pngquant. 

Even though the wrapper code may itself be MIT, I think marking the whole package with pngquant inside as MIT gives false impression that it can be used in MIT terms.
