### PR TITLE
Log original error for easier debugging of the underlying build error

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -20,7 +20,7 @@ bin.run(['--version']).then(() => {
 	]).then(() => {
 		log.success('pngquant built successfully');
 	}).catch(err => {
-		err.message = `pngquant failed to build, make sure that ${libpng} is installed`;
+		log.error(`pngquant failed to build -- usually this happens because ${libpng} is not installed`);
 		log.error(err.stack);
 
 		// eslint-disable-next-line unicorn/no-process-exit


### PR DESCRIPTION
Currently, when a build error occurs, the `catch` within `lib/install.js` is overriding the error's message with a static error message. This ends up hiding the underlying issue. In my case, on OSX `10.14.2` I did a `brew install libpng` per the static error message and nothing changed. This caused me wonder what was actually happening. Upon digging into the source it became clear the actual build error was not being surfaced. This change surfaces the real underlying issue. See the before and after output below:

**Before**
```bash
~/Git/pngquant-bin (master) $ node lib/install.js 
  ⚠ unable to get local issuer certificate
  ⚠ pngquant pre-build test failed
  ℹ compiling from source
  ✖ Error: pngquant failed to build, make sure that libpng is installed
    at Promise.all.then.arr (/Users/gesell/Git/pngquant-bin/node_modules/bin-build/node_modules/execa/index.js:231:11)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```
**After**
```bash
~/Git/pngquant-bin (master) $ node lib/install.js 
  ⚠ unable to get local issuer certificate
  ⚠ pngquant pre-build test failed
  ℹ compiling from source
  ✖ pngquant failed to build -- usually this happens because libpng is not installed
  ✖ Error: Command failed: /bin/sh -c ./configure --prefix="/Users/gesell/Git/pngquant-bin/vendor"


  Compiler: gcc
     Debug: no
       SSE: yes
    OpenMP: no
imagequant: build static
    libpng: shared (1.6.37)
      zlib: error ... not found (please install zlib-devel package)


    at Promise.all.then.arr (/Users/gesell/Git/pngquant-bin/node_modules/bin-build/node_modules/execa/index.js:231:11)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```
A quick search on `zlib-devel` for OSX turned up an SO post: https://stackoverflow.com/questions/23749530/brew-install-zlib-devel-on-mac-os-x-mavericks which made me realize I had an issue with my `xcode-select` tools. Without the more descriptive error, I wouldn't have realized what was actually causing my issue.