### PR TITLE
make bin-wrapper read url value from env vars.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@ const path = require('path');
 const BinWrapper = require('bin-wrapper');
 const pkg = require('../package.json');
 
-const url = `https://raw.githubusercontent.com/imagemin/pngquant-bin/v${pkg.version}/vendor/`;
+const url = `${process.env.PNGQUANT_BIN_BASE_URL || 'https://raw.githubusercontent.com/imagemin/pngquant-bin/'}v${pkg.version}/vendor/`;
 
 module.exports = new BinWrapper()
 	.src(`${url}macos/pngquant`, 'darwin')


### PR DESCRIPTION
for those who can not access `raw.githubusercontent.com` normally, they can install this package with the following command
```
PNGQUANT_BIN_BASE_URL=https://npm.taobao.org/mirrors/pngquant-bin/ npm i -S pngquant-bin
```