### PR TITLE
Feat/allow-for-github-raw-url

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,10 @@ const path = require('path');
 const BinWrapper = require('bin-wrapper');
 const pkg = require('../package.json');
 
-const url = `https://raw.githubusercontent.com/imagemin/pngquant-bin/v${pkg.version}/vendor/`;
+const GITHUB_RAW_URL = process.env.GITHUB_RAW_URL
+  ? process.env.GITHUB_RAW_URL
+  : 'https://raw.githubusercontent.com';
+const url = `${GITHUB_RAW_URL}}/imagemin/pngquant-bin/v${pkg.version}/vendor/`;
 
 module.exports = new BinWrapper()
 	.src(`${url}macos/pngquant`, 'darwin')

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,10 @@ You probably want [`imagemin-pngquant`](https://github.com/imagemin/imagemin-png
 $ npm install pngquant-bin
 ```
 
+If you wish to pull through your own internal mirror you can use `GITHUB_RAW_URL`
+to point the postinstall step to pull through your mirror. By default, this package
+attempts to install from `https://raw.githubusercontent.com` on postinstall, and compiles
+otherwise if the connection can't be made.
 
 ## Usage
 


### PR DESCRIPTION
Allow the user to pass the base url to pull the binaries through.
Useful for airgapped systems