### PR TITLE
custom the bin download url

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,9 @@ import {fileURLToPath} from 'node:url';
 import BinWrapper from 'bin-wrapper';
 
 const pkg = JSON.parse(fs.readFileSync(new URL('../package.json', import.meta.url)));
-const url = `https://raw.githubusercontent.com/imagemin/pngquant-bin/v${pkg.version}/vendor/`;
+const url =
+	process.env.PNGQUANT_BINARY_URL ||
+	`https://raw.githubusercontent.com/imagemin/pngquant-bin/v${pkg.version}/vendor/`;
 
 const binWrapper = new BinWrapper()
 	.src(`${url}macos/pngquant`, 'darwin')


### PR DESCRIPTION
Because of some reason. The site raw.githubusercontent.com is not reachable, need a ENV setting to custom the binary download url