### PR TITLE
Drop Node.js 12 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ jobs:
         node-version:
           - 16
           - 14
-          - 12
         os:
           - ubuntu-latest
           - macos-latest

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"pngquant": "cli.js"
 	},
 	"engines": {
-		"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+		"node": "^14.13.1 || >=16.0.0"
 	},
 	"scripts": {
 		"postinstall": "node lib/install.js",

--- a/package.json
+++ b/package.json
@@ -51,13 +51,13 @@
 	"dependencies": {
 		"bin-build": "^3.0.0",
 		"bin-wrapper": "^4.0.1",
-		"execa": "^5.1.1"
+		"execa": "^6.1.0"
 	},
 	"devDependencies": {
-		"ava": "^3.15.0",
+		"ava": "^4.1.0",
 		"bin-check": "^4.0.1",
 		"compare-size": "^3.0.0",
 		"tempy": "^2.0.0",
-		"xo": "^0.45.0"
+		"xo": "^0.48.0"
 	}
 }

--- a/test.js
+++ b/test.js
@@ -3,7 +3,7 @@ import path from 'node:path';
 import process from 'node:process';
 import {fileURLToPath} from 'node:url';
 import test from 'ava';
-import execa from 'execa';
+import {execa} from 'execa';
 import tempy from 'tempy';
 import binCheck from 'bin-check';
 import binBuild from 'bin-build';
@@ -18,7 +18,7 @@ test('rebuild the pngquant binaries', async t => {
 	}
 
 	const temporary = tempy.directory();
-	const source = fileURLToPath(new URL('./vendor/source/pngquant.tar.gz', import.meta.url));
+	const source = fileURLToPath(new URL('vendor/source/pngquant.tar.gz', import.meta.url));
 
 	await binBuild.file(source, [
 		'rm ./INSTALL',
@@ -35,7 +35,7 @@ test('verify binary', async t => {
 
 test('minify a png', async t => {
 	const temporary = tempy.directory();
-	const src = fileURLToPath(new URL('./fixtures/test.png', import.meta.url));
+	const src = fileURLToPath(new URL('fixtures/test.png', import.meta.url));
 	const dest = path.join(temporary, 'test.png');
 	const args = [
 		'-o',


### PR DESCRIPTION
Node.js 12 is going to be outdated in the near future ([2022-04-30](https://nodejs.org/en/about/releases/)).