### PR TITLE
Add CDN Mirrors support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,9 @@ import {fileURLToPath} from 'node:url';
 import BinWrapper from 'bin-wrapper';
 
 const pkg = JSON.parse(fs.readFileSync(new URL('../package.json', import.meta.url)));
-const url = `https://raw.githubusercontent.com/imagemin/pngquant-bin/v${pkg.version}/vendor/`;
+
+const baseUrl = process.env.npm_config_pngquant_bin_host_mirror || 'https://raw.githubusercontent.com/imagemin/pngquant-bin';
+const url =  `${baseUrl}/v${pkg.version}/vendor/`;
 
 const binWrapper = new BinWrapper()
 	.src(`${url}macos/pngquant`, 'darwin')


### PR DESCRIPTION
```bash
npm config set pngquant_bin_host_mirror "https://npmmirror.com/mirrors/pngquant-bin"
npm install pngquant-bin
```
Very usefull when in private network!
