### PR TITLE
Fix execa import for CLI entrypoint

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import process from 'node:process';
-import execa from 'execa';
+import {execa} from 'execa';
 import pngquant from './index.js';
 
 execa(pngquant, process.argv.slice(2), {stdio: 'inherit'});


### PR DESCRIPTION
Corrects the import for `execa` to allow the CLI entrypoint to work; compare to https://github.com/imagemin/pngquant-bin/blame/main/test.js#L6.

Fixes #138.