### PR TITLE
fix crash at installation on linux platforms with non-intel archs

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -3,27 +3,41 @@ import {fileURLToPath} from 'node:url';
 import binBuild from 'bin-build';
 import bin from './index.js';
 
-bin.run(['--version']).then(() => {
-	console.log('pngquant pre-build test passed successfully');
-}).catch(async error => {
-	console.warn(error.message);
-	console.warn('pngquant pre-build test failed');
-	console.info('compiling from source');
-
+(async () => {
 	try {
-		const source = fileURLToPath(new URL('../vendor/source/pngquant.tar.gz', import.meta.url));
+		// On linux platforms with non-intel architectures, bin-wrapper still
+		// downloads and tries to execute the x86_64 ELF. This results in the
+		// binary file being interpreted as a shell script, which creates a
+		// dangling file that can make npm or yarn crash at installation. This
+		// condition prevents this from happening.
+		//
+		// See https://github.com/imagemin/gifsicle-bin/issues/124#issuecomment-1222646680
+		if (process.platform === 'linux' && !['ia32', 'x64'].includes(process.arch)) {
+			throw Error(`Unsupported platform: ${process.platform}/${process.arch}.`);
+		}
 
-		await binBuild.file(source, [
-			'rm ./INSTALL',
-			`./configure --prefix="${bin.dest()}"`,
-			`make install BINPREFIX="${bin.dest()}"`,
-		]);
+		await bin.run(['--version']);
+		console.log('pngquant pre-build test passed successfully');
+	} catch(error) {
+		console.warn(error.message);
+		console.warn('pngquant pre-build test failed');
+		console.info('compiling from source');
 
-		console.log('pngquant built successfully');
-	} catch (error) {
-		console.error(error.stack);
+		try {
+			const source = fileURLToPath(new URL('../vendor/source/pngquant.tar.gz', import.meta.url));
 
-		// eslint-disable-next-line unicorn/no-process-exit
-		process.exit(1);
+			await binBuild.file(source, [
+				'rm ./INSTALL',
+				`./configure --prefix="${bin.dest()}"`,
+				`make install BINPREFIX="${bin.dest()}"`,
+			]);
+
+			console.log('pngquant built successfully');
+		} catch (error) {
+			console.error(error.stack);
+
+			// eslint-disable-next-line unicorn/no-process-exit
+			process.exit(1);
+		}
 	}
-});
+})();


### PR DESCRIPTION
See https://github.com/imagemin/gifsicle-bin/issues/124#issuecomment-1222646680 for all the details. Note that this bug should probably be addressed in [os-filter-obj](https://github.com/kevva/os-filter-obj/issues/3) / bin-wrapper, but the projects have been unmaintained for a few years.